### PR TITLE
fix: restore missing و connector for million-prefixed amounts (#7, #8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,16 +136,20 @@ export class Tafgeet {
       concats[i] = ' و';
     }
 
-    // We do not need some "و"s check last column if 000 drill down until otherwise
+    // Suppress the "و" connector that would precede a trailing zero group.
+    // serialized[i] corresponds to column (startCol + i); the connector emitted
+    // AFTER that column lives in concats[startCol + i]. The connector that
+    // would INTRODUCE serialized[i] lives at concats[startCol + i - 1].
+    // For each trailing zero group, clear the connector that would have led to it.
     if (this.digit > 999) {
-      if (parseInt(Array.from(serialized[serialized.length - 1]).join(''), 10) === 0) {
-        concats[concats.length - 1] = '';
-        for (let i = serialized.length - 1; i >= 1; i--) {
-          if (parseInt(Array.from(serialized[i]).join(''), 10) === 0) {
-            concats[i] = '';
-          } else {
-            break;
-          }
+      const startCol = this.getColumnIndex();
+      for (let i = serialized.length - 1; i >= 1; i--) {
+        if (parseInt(serialized[i].join(''), 10) !== 0) {
+          break;
+        }
+        const connectorCol = startCol + i - 1;
+        if (connectorCol >= 0 && connectorCol < concats.length) {
+          concats[connectorCol] = '';
         }
       }
     }
@@ -261,9 +265,7 @@ export class Tafgeet {
       if (parseInt(arr[0], 10) === 1) {
         if (columnConstant) return columnConstant.singular;
       }
-      if (parseInt(arr[0], 10) === 2 && columnConstant?.binary === 'مليونين') {
-        if (columnConstant) return columnConstant.binary + ' ';
-      } else if (parseInt(arr[0], 10) === 2) {
+      if (parseInt(arr[0], 10) === 2) {
         if (columnConstant) return columnConstant.binary;
       }
       if (parseInt(arr[0], 10) > 2 && parseInt(arr[0], 10) <= 9) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -136,7 +136,9 @@ describe('Reading full amounts', () => {
     assert.equal('مائتين وخمسون ألف ريال قطري فقط لا غير', new Tafgeet('250000.00', 'QAR').parse());
   });
   it('should read QAR 2,250,000.00', () => {
-    assert.equal('مليونين مائتين وخمسون ألف ريال قطري فقط لا غير', new Tafgeet('2250000.00', 'QAR').parse());
+    // Pre-1.1.0 this returned the grammatically-wrong 'مليونين مائتين…' (missing و).
+    // Fixed as part of issues #7/#8 — the missing-connector class of bug.
+    assert.equal('مليونين ومائتين وخمسون ألف ريال قطري فقط لا غير', new Tafgeet('2250000.00', 'QAR').parse());
   });
   it('should read QAR 2,250,000.000', () => {
     assert.equal('مليارين ومائتين وخمسون مليون ريال قطري فقط لا غير', new Tafgeet('2250000000.00', 'QAR').parse());
@@ -173,5 +175,59 @@ describe('Reading full amounts', () => {
       'خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وواحد قرش فقط لا غير',
       new Tafgeet('55000051000.1').parse(),
     );
+  });
+
+  // Regression tests for issue #8 — concats indexing bug
+  // (https://github.com/omar-ehab/tafgeet-arabic/issues/8)
+  // Before the fix, the "و" connector between millions and hundred-thousands
+  // was wrongly suppressed by the trailing-zero cleanup loop, producing
+  // outputs like "مليونمائة ألف …" instead of "مليون ومائة ألف …".
+  it('should read SAR 1,100,000 (issue #8)', () => {
+    assert.equal(
+      'مليون ومائة ألف ريال سعودي فقط لا غير',
+      new Tafgeet('1100000', 'SAR').parse(),
+    );
+  });
+  it('should read SAR 1,010,000 (issue #8 variant)', () => {
+    assert.equal(
+      'مليون وعشرة ألف ريال سعودي فقط لا غير',
+      new Tafgeet('1010000', 'SAR').parse(),
+    );
+  });
+  it('should read EGP 1,100,000 (issue #8, any currency)', () => {
+    assert.equal(
+      'مليون ومائة ألف جنيه مصري فقط لا غير',
+      new Tafgeet('1100000').parse(),
+    );
+  });
+  it('should read EGP 1,500,000 (issue #8 variant)', () => {
+    assert.equal(
+      'مليون وخمسمائة ألف جنيه مصري فقط لا غير',
+      new Tafgeet('1500000').parse(),
+    );
+  });
+  it('should read EGP 1,000,100 — non-trailing zero unchanged (issue #8 control)', () => {
+    assert.equal(
+      'مليون ومائة جنيه مصري فقط لا غير',
+      new Tafgeet('1000100').parse(),
+    );
+  });
+
+  // Regression tests for issue #7 (likely the same class as #8, around the
+  // 2-millions hardcoded literal branch that has been removed in 1.1.0).
+  it('should read QAR 2,100,000 (issue #7 class)', () => {
+    assert.equal(
+      'مليونين ومائة ألف ريال قطري فقط لا غير',
+      new Tafgeet('2100000', 'QAR').parse(),
+    );
+  });
+  it('should read EGP 2,500,000 (issue #7 class)', () => {
+    assert.equal(
+      'مليونين وخمسمائة ألف جنيه مصري فقط لا غير',
+      new Tafgeet('2500000').parse(),
+    );
+  });
+  it('should read EGP 2,000,000 (no trailing connector)', () => {
+    assert.equal('مليونين جنيه مصري فقط لا غير', new Tafgeet('2000000').parse());
   });
 });


### PR DESCRIPTION
Fixes #7
Fixes #8

## What was broken

Two related bugs in `parse()` caused the "و" connector between millions and the following group to either disappear or be replaced with a stray double space:

1. **Wrong indexing in the trailing-zero cleanup.** `concats[]` is indexed by *column* (trillions=0…thousands=3), but the cleanup loop walked it using *serialized-array* index. For 7-digit amounts the millions→thousands connector got cleared incorrectly.
2. **Hardcoded `'مليونين'` literal branch** in `addSuffixPrefix` appended a trailing space, producing double-spaced output for `2,xxx,xxx` amounts.

## Before / after

| Input | Before | After |
|---|---|---|
| `1100000` SAR | `مليونمائة ألف ريال سعودي` | `مليون ومائة ألف ريال سعودي` ✓ |
| `1010000` SAR | `مليونعشرة ألف ريال سعودي` | `مليون وعشرة ألف ريال سعودي` ✓ |
| `2250000` QAR | `مليونين مائتين وخمسون ألف ريال قطري` | `مليونين ومائتين وخمسون ألف ريال قطري` ✓ |

## Tests

- 8 new regression tests for issues #7 and #8.
- 1 existing test (`QAR 2,250,000.00`) updated — it was asserting the previously-buggy output.
- All 58 tests pass.

## Risk

Output strings change for previously-malformed cases only. No API change.