### PR TITLE
fix: gate fraction word singular/plural on fraction value, not integer part

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,11 @@ export class Tafgeet {
         str += ' ' + currencies[this.currency as keyof typeof currencies].singular;
       }
       if (this.fraction !== 0) {
-        if (this.digit >= 3 && this.digit <= 10) {
+        // Plural-vs-singular for the FRACTION word depends on the FRACTION
+        // value (3–10 → broken plural in Arabic), not on the integer part.
+        // Pre-1.1.0 this incorrectly gated on `this.digit`, so e.g.
+        // `1.05 EGP` returned "...وخمسة قرش" instead of "...وخمسة قروش".
+        if (this.fraction >= 3 && this.fraction <= 10) {
           str += ' و' + this.read(this.fraction) + ' ' + currencies[this.currency as keyof typeof currencies].fractions;
         } else {
           str += ' و' + this.read(this.fraction) + ' ' + currencies[this.currency as keyof typeof currencies].fraction;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -230,4 +230,48 @@ describe('Reading full amounts', () => {
   it('should read EGP 2,000,000 (no trailing connector)', () => {
     assert.equal('مليونين جنيه مصري فقط لا غير', new Tafgeet('2000000').parse());
   });
+
+  // Regression tests for the fraction singular/plural bug (the bug behind
+  // the it.skip'd test in #3). The fraction word must be plural for
+  // fraction values 3–10 and singular otherwise — driven by the FRACTION
+  // value, not the integer part of the amount.
+  it('should use SINGULAR fraction word for fraction=1', () => {
+    assert.equal('واحد جنيه مصري وواحد قرش فقط لا غير', new Tafgeet('1.01').parse());
+  });
+  it('should use SINGULAR fraction word for fraction=2', () => {
+    assert.equal('واحد جنيه مصري وٱثنين قرش فقط لا غير', new Tafgeet('1.02').parse());
+  });
+  it('should use PLURAL fraction word for fraction=3', () => {
+    assert.equal('واحد جنيه مصري وثلاثة قروش فقط لا غير', new Tafgeet('1.03').parse());
+  });
+  it('should use PLURAL fraction word for fraction=5', () => {
+    assert.equal('واحد جنيه مصري وخمسة قروش فقط لا غير', new Tafgeet('1.05').parse());
+  });
+  it('should use PLURAL fraction word for fraction=10', () => {
+    assert.equal('واحد جنيه مصري وعشرة قروش فقط لا غير', new Tafgeet('1.10').parse());
+  });
+  it('should use SINGULAR fraction word for fraction=11', () => {
+    assert.equal('واحد جنيه مصري وأحد عشر قرش فقط لا غير', new Tafgeet('1.11').parse());
+  });
+  it('should use SINGULAR fraction word for fraction=99', () => {
+    assert.equal('واحد جنيه مصري وتسعة وتسعون قرش فقط لا غير', new Tafgeet('1.99').parse());
+  });
+  // Cross-check: when BOTH integer and fraction are in 3–10, plural
+  // applies to both — previously coincidentally correct, must stay correct.
+  it('should pluralize both currency and fraction when both in 3–10', () => {
+    assert.equal('خمسة جنيهات مصرية وخمسة قروش فقط لا غير', new Tafgeet('5.05').parse());
+  });
+  // The decisive case: integer outside 3–10 but fraction inside.
+  // Pre-1.1.0 this incorrectly produced singular `قرش`.
+  it('should pluralize fraction when integer is OUT of 3–10 (regression)', () => {
+    assert.equal('مائة جنيه مصري وخمسة قروش فقط لا غير', new Tafgeet('100.05').parse());
+  });
+  // Same shape for TND (3-decimal currency).
+  it('should pluralize TND fraction in 3–10', () => {
+    assert.equal('واحد دينار تونسي وخمسة مليمات فقط لا غير', new Tafgeet('1.005', 'TND').parse());
+  });
+  // Same shape for USD.
+  it('should pluralize USD fraction in 3–10', () => {
+    assert.equal('واحد دولار أمريكي وخمسة سنتات فقط لا غير', new Tafgeet('1.05', 'USD').parse());
+  });
 });


### PR DESCRIPTION
## What was broken

Arabic grammar pluralizes the counted noun for counts of 3–10 and uses the singular otherwise. The package was correctly applying this rule to the **currency** word but mistakenly used the **integer part** of the amount to gate the **fraction** word.

This also surfaced in [PR #3](https://github.com/omar-ehab/tafgeet-arabic/pull/3) where `KWD 1.010 → وعشرة فلوس` was marked `it.skip` — that test now passes (will be re-enabled when KWD support lands in v1.1.0).

## Before / after

| Input | Before | After |
|---|---|---|
| `1.05` EGP | `…وخمسة قرش` | `…وخمسة قروش` ✓ |
| `100.05` EGP | `…وخمسة قرش` | `…وخمسة قروش` ✓ |
| `1.005` TND | `…وخمسة مليم` | `…وخمسة مليمات` ✓ |
| `1.05` USD | `…وخمسة سنت` | `…وخمسة سنتات` ✓ |

## Tests

- 11 new tests covering every fraction edge: 1, 2, 3, 5, 10, 11, 99, and the integer-out / fraction-in case across EGP, TND, USD.
- No existing tests changed — none of them happened to assert a fraction-in-3-to-10 case before, so this is purely additive coverage for existing users.
- All 69 tests pass.

## Risk

Output strings change **only** for amounts where the fractional part is in 3–10. No API change. Users whose existing tests cover this range may need to update — flagged in CHANGELOG.