### PR TITLE
feat: add KWD (Kuwaiti Dinar) currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const stringText = new Tafgeet(55000051000.2, 'EGP').parse();
 - QAR (Qatari Riyal)
 - AED (Emarati Dirham)
 - EGP (Egyptian Pound) - *Default*
+- KWD (Kuwaiti Dinar)
 - USD (US Dollar)
 - TND (Tunisian Dinar)
 - AUD (Australian Dollar)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,13 @@ export const currencies: Currencies = {
     fractions: 'قروش',
     decimals: 2,
   },
+  KWD: {
+    singular: 'دينار كويتي',
+    plural: 'دنانير كويتية',
+    fraction: 'فلس',
+    fractions: 'فلوس',
+    decimals: 3,
+  },
   USD: {
     singular: 'دولار أمريكي',
     plural: 'دولارات أمريكية',

--- a/src/interfaces/currency.ts
+++ b/src/interfaces/currency.ts
@@ -4,6 +4,7 @@ export interface Currencies {
   QAR: Currency;
   AED: Currency;
   EGP: Currency;
+  KWD: Currency;
   USD: Currency;
   AUD: Currency;
   TND: Currency;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -276,6 +276,73 @@ describe('Reading full amounts', () => {
   });
 });
 
+describe('KWD (Kuwaiti Dinar — 3 decimals, originally proposed in PR #3)', () => {
+  // Integer amounts — exercises singular/dual/plural for the currency word.
+  it('should read KWD 1', () => {
+    assert.equal('واحد دينار كويتي فقط لا غير', new Tafgeet('1', 'KWD').parse());
+  });
+  it('should read KWD 2', () => {
+    assert.equal('ٱثنين دينار كويتي فقط لا غير', new Tafgeet('2', 'KWD').parse());
+  });
+  it('should read KWD 3 (plural)', () => {
+    assert.equal('ثلاثة دنانير كويتية فقط لا غير', new Tafgeet('3', 'KWD').parse());
+  });
+  it('should read KWD 10 (plural)', () => {
+    assert.equal('عشرة دنانير كويتية فقط لا غير', new Tafgeet('10', 'KWD').parse());
+  });
+  it('should read KWD 11 (singular)', () => {
+    assert.equal('أحد عشر دينار كويتي فقط لا غير', new Tafgeet('11', 'KWD').parse());
+  });
+
+  // Fractions — 3-decimal currency. The fraction-plural rule applies to
+  // the FRACTION value (3–10 fils → فلوس, otherwise فلس).
+  it('should read KWD 1.001 (1 fils)', () => {
+    assert.equal('واحد دينار كويتي وواحد فلس فقط لا غير', new Tafgeet('1.001', 'KWD').parse());
+  });
+  it('should read KWD 1.005 (5 fils — plural)', () => {
+    assert.equal('واحد دينار كويتي وخمسة فلوس فقط لا غير', new Tafgeet('1.005', 'KWD').parse());
+  });
+  // This is the case PR #3 marked as it.skip — it now passes unchanged,
+  // because the fraction-plural fix (PR #10) gates on the fraction value.
+  it('should read KWD 1.010 (10 fils — plural, previously skipped in PR #3)', () => {
+    assert.equal('واحد دينار كويتي وعشرة فلوس فقط لا غير', new Tafgeet('1.010', 'KWD').parse());
+  });
+  it('should read KWD 1.100 (100 fils — singular)', () => {
+    assert.equal('واحد دينار كويتي ومائة فلس فقط لا غير', new Tafgeet('1.100', 'KWD').parse());
+  });
+  it('should read KWD 2.500 (500 fils — singular)', () => {
+    assert.equal('ٱثنين دينار كويتي وخمسمائة فلس فقط لا غير', new Tafgeet('2.500', 'KWD').parse());
+  });
+
+  // 3-decimal precision is preserved (vs SDG which truncates the 3rd).
+  it('should read KWD 123.456 (3-decimal precision)', () => {
+    assert.equal(
+      'مائة وثلاثة وعشرون دينار كويتي وأربعمائة وستة وخمسون فلس فقط لا غير',
+      new Tafgeet('123.456', 'KWD').parse(),
+    );
+  });
+
+  // Large amounts — exercises thousands/millions/billions with KWD.
+  it('should read KWD 1,000', () => {
+    assert.equal('ألف دينار كويتي فقط لا غير', new Tafgeet('1000', 'KWD').parse());
+  });
+  it('should read KWD 1,000,000', () => {
+    assert.equal('مليون دينار كويتي فقط لا غير', new Tafgeet('1000000', 'KWD').parse());
+  });
+  it('should read KWD 1,100,000 (issue #8 fix still applies for KWD)', () => {
+    assert.equal('مليون ومائة ألف دينار كويتي فقط لا غير', new Tafgeet('1100000', 'KWD').parse());
+  });
+  it('should read KWD 1,000,000,000', () => {
+    assert.equal('مليار دينار كويتي فقط لا غير', new Tafgeet('1000000000', 'KWD').parse());
+  });
+  it('should read KWD 1,234,567.890 (mixed, large + 3-decimal fraction)', () => {
+    assert.equal(
+      'مليون ومائتين وأربعة وثلاثون ألف وخمسمائة وسبعة وستون دينار كويتي وثمانمائة وتسعون فلس فقط لا غير',
+      new Tafgeet('1234567.890', 'KWD').parse(),
+    );
+  });
+});
+
 describe('Input validation (1.1.0)', () => {
   describe('rejects with TypeError', () => {
     it('null amount', () => {
@@ -339,7 +406,7 @@ describe('Input validation (1.1.0)', () => {
     it('throws with helpful list of supported codes', () => {
       assert.throws(
         () => new Tafgeet(5, 'XYZ'),
-        /unknown currency "XYZ"\. Supported: SDG, SAR, QAR, AED, EGP, USD, AUD, TND, TRY/,
+        /unknown currency "XYZ"\. Supported: SDG, SAR, QAR, AED, EGP, KWD, USD, AUD, TND, TRY/,
       );
     });
   });


### PR DESCRIPTION
Closes [#3](https://github.com/omar-ehab/tafgeet-arabic/pull/3) (re-implements with attribution to @thenbe in the commit + CHANGELOG).

## What's added

The Kuwaiti Dinar — a 3-decimal currency (1 KWD = 1000 fils):

| | |
|---|---|
| singular | `دينار كويتي` |
| plural | `دنانير كويتية` |
| fraction | `فلس` |
| fractions | `فلوس` |
| decimals | 3 |

## Why re-implement vs. merging PR #3

PR #3 has been open since Oct 2023. It marked the `KWD 1.010 → وعشرة فلوس` test as `it.skip` because of an underlying fraction-plural bug that wasn't KWD-specific. That bug is now fixed in v1.1.0 (PR #11), so this PR ships KWD with a complete test suite — no skipped tests, the `1.010` case included.

Full credit to @thenbe in both the commit message and CHANGELOG.

## Tests

16 new tests covering:

- **Integer cases:** 1, 2, 3, 10, 11 — exercises singular/dual/plural for the currency word
- **Fraction cases:** 1, 5, 10, 100, 500 fils — exercises the fraction-plural rule for a 3-decimal currency, including the previously-skipped `1.010`
- **Large amounts:** 1,000 / 1,000,000 / 1,100,000 / 1,000,000,000 / 1,234,567.890
- **3-decimal precision:** `123.456 KWD → ...وأربعمائة وستة وخمسون فلس`
- Verifies that the issue #7/#8 connector fix also applies for KWD (`1,100,000 KWD → مليون ومائة ألف دينار كويتي`)

All 107 tests pass.

## After merge

I'll post a thank-you comment on the original PR [#3](https://github.com/omar-ehab/tafgeet-arabic/pull/3) and close it.