### PR TITLE
chore: release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,153 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] – 2026-05-27
+
+A correctness, performance, and developer-experience release.
+
+**No breaking API changes.** Output strings change only for inputs that
+previously produced grammatically wrong Arabic or literal `"undefined"`.
+The class signature, methods, and behavior for all currently-correct
+inputs are byte-identical to v1.0.11.
+
+### Added
+
+- **KWD (Kuwaiti Dinar)** currency support, 3-decimal precision (1 KWD = 1000 fils).
+  Originally proposed by [@thenbe](https://github.com/omar-ehab/tafgeet-arabic/pull/3); re-implemented on top of the
+  fraction-plural fix below so no tests need `it.skip`.
+- **Input validation** with clear, typed errors:
+  - `TypeError` for `null`, `undefined`, wrong type, non-numeric strings,
+    empty strings, scientific notation, non-string currency.
+  - `RangeError` for `NaN`, `±Infinity`, negative amounts, zero (integer
+    part < 1), and >15-digit integers.
+  - `Error` for unknown currency codes (the error lists all supported codes).
+  Pre-1.1.0 these inputs either crashed with cryptic `TypeError`s or
+  silently produced strings containing the literal word `"undefined"`.
+- **Public type exports** — TypeScript consumers can now import the
+  types directly:
+  ```ts
+  import { Tafgeet, Currency, Currencies, NumberProperties } from 'tafgeet-arabic';
+  ```
+  Previously these types were unreachable without deep-importing
+  internal paths.
+- **TypeScript declaration files (`.d.ts`) shipping in the published
+  package.** Previously enabled in tsconfig but the flag was commented
+  out — TS consumers got no types. Now `dist/src/index.d.ts` is shipped.
+- **`engines` field** declares `node >= 18.18.0` (the floor for the
+  underlying mocha/eslint stack; the package runtime itself works on
+  any Node ≥ 12 in practice).
+- **JS-compat smoke test** (`npm run test:js-compat`) that exercises the
+  built package from plain CommonJS — proving it works for vanilla JS
+  consumers, not just TypeScript.
+
+### Changed
+
+- **3.5–4.7× faster** across all input sizes. Per-call constructor cost
+  dropped from ~4 µs to ~1 µs on typical amounts. Wins come from:
+  - Number-word dictionaries moved to module-level frozen constants
+    (was: 14 object literals allocated per `new Tafgeet()` call).
+  - String-digit indexing (`Array.from(d.toString())[i]`) replaced with
+    arithmetic (`Math.floor(d / 10)`, `d % 10`).
+  - `parse()` rewritten with a clean 3-digit grouping algorithm.
+
+  | Case | Before | After |
+  | --- | --- | --- |
+  | Small (3 digits) | 503k ops/s | **2,348k ops/s** |
+  | Medium (7 digits) | 248k ops/s | **932k ops/s** |
+  | Large (13 digits) | 170k ops/s | **636k ops/s** |
+  | Fractional | 222k ops/s | **830k ops/s** |
+  | KWD 3-decimal | 212k ops/s | **748k ops/s** |
+- **52% smaller unpacked install size** (44 kB → 21 kB). Test files were
+  being compiled into `dist/test/` and shipped to every consumer (23 kB
+  of test code per install) because the `tsconfig` exclude listed
+  `./tests/` instead of `./test/`. Fixed.
+- **Cross-platform `npm test`.** The test script used Unix `env`,
+  breaking on Windows. The override was actually redundant with the
+  existing tsconfig — removing it makes the script work on PowerShell,
+  cmd, and bash without needing `cross-env`.
+- **CI matrix expanded** from `ubuntu-latest` × Node 20 to
+  `[ubuntu-latest, windows-latest]` × `[20, 22]`, with `lint`,
+  `format:check`, and `test:js-compat` added to the pipeline.
+
+### Fixed
+
+- **Issue [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7) /
+  Issue [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8)** — the
+  "و" connector between million-prefixed amounts and the following group
+  was missing or wrong:
+  - `new Tafgeet('1100000', 'SAR').parse()`
+    - Before: `مليونمائة ألف ريال سعودي فقط لا غير`
+    - After:  `مليون ومائة ألف ريال سعودي فقط لا غير` ✓
+  - `new Tafgeet('2250000', 'QAR').parse()`
+    - Before: `مليونين مائتين وخمسون ألف ريال قطري فقط لا غير`
+    - After:  `مليونين ومائتين وخمسون ألف ريال قطري فقط لا غير` ✓
+
+  Root causes: (1) the trailing-zero connector-cleanup loop indexed the
+  `concats[]` array by serialized-group index rather than column index;
+  (2) a hardcoded `'مليونين'` literal special case appended a stray
+  trailing space.
+
+- **Fraction word singular/plural** — Arabic uses the broken-plural form
+  for counts 3–10. The package gated this rule on the **integer part**
+  of the amount instead of the **fraction value**, so fractions in the
+  3–10 range got the singular form:
+  - `new Tafgeet('1.05').parse()`
+    - Before: `واحد جنيه مصري وخمسة قرش فقط لا غير`
+    - After:  `واحد جنيه مصري وخمسة قروش فقط لا غير` ✓
+  - `new Tafgeet('1.005', 'TND').parse()`
+    - Before: `واحد دينار تونسي وخمسة مليم فقط لا غير`
+    - After:  `واحد دينار تونسي وخمسة مليمات فقط لا غير` ✓
+
+### Security
+
+- **All `npm audit` vulnerabilities resolved** (was: 11 vulnerabilities;
+  is: 0). The bulk came from `tslint`'s transitive deps (removed in
+  the ESLint migration); the remaining mocha-transitive CVEs are
+  pinned to patched versions via `package.json` `overrides`.
+
+### Internal / Tooling
+
+These don't affect consumers but improve maintainability and DX:
+
+- **TypeScript upgraded 4.9 → 5.9.**
+- **All devDependencies bumped to current majors:** `mocha` 10 → 11,
+  `chai` 4 → 6, `prettier` 2 → 3, `ts-node` to latest, `@types/*`
+  to match.
+- **`tsconfig` strictness tightened** — every `strict`-family flag
+  explicit, plus `noUnusedLocals`, `noUnusedParameters`,
+  `noImplicitReturns`, `noFallthroughCasesInSwitch`,
+  `noImplicitOverride`, **`noUncheckedIndexedAccess`**.
+- **`tslint` → ESLint 9 (flat config)** with `typescript-eslint`
+  strict + recommended rule sets. `tslint` had been deprecated since
+  2019 and accounted for most of the security vulnerabilities.
+- **File structure** consolidated — `src/interfaces/currency.ts` and
+  `src/interfaces/NumberProperties.ts` merged into a single
+  `src/types.ts`. `interfaces/` directory removed.
+- **`bower.json` removed** (Bower deprecated 2017).
+- **`.gitattributes`** added — forces LF line endings, prevents Windows
+  contributors from accidentally committing CRLF.
+
+### Removed
+
+- **Eight `private` instance fields** on the `Tafgeet` class
+  (`this.ones`, `this.teens`, `this.tens`, `this.hundreds`,
+  `this.thousands`, `this.millions`, `this.billions`, `this.trillions`).
+  These were always declared `private`, never documented as part of the
+  API, and never exported. Consumers needing direct access to the
+  dictionaries should import the constants from `tafgeet-arabic/dist/src/constants`
+  (or wait for a future minor that re-exports them publicly).
+
+### Credits
+
+- [@kishoreaoe](https://github.com/kishoreaoe) — reported issue #7 (millions wording for QAR).
+- [@Ahmed-Elashmony](https://github.com/Ahmed-Elashmony) — reported issue #8 with a clean numeric reproducer.
+- [@thenbe](https://github.com/thenbe) — proposed KWD support in PR #3, surfaced the
+  underlying fraction-plural bug that was fixed in this release.
+
+## [1.0.11] – 2023-01-25
+
+Last release before the v1.1.0 series. See git history for prior changes.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,23 @@ const stringText = new Tafgeet(55000051000.2, 'EGP').parse();
 - AUD (Australian Dollar)
 - TRY (Turkish Lira)
 
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for release notes. Highlights of **v1.1.0**:
+
+- **3.5–4.7× faster** across all input sizes
+- **52% smaller** install size (test files no longer published)
+- **Bug fixes** for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7), [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8), and the fraction singular/plural rule
+- **KWD (Kuwaiti Dinar)** currency added
+- **Input validation** — bad input throws typed errors instead of silent garbage
+- **TypeScript types** ship in the package and are re-exported from the entry point
+
+## Requirements
+
+- Node.js **≥ 18.18.0**
+
 ## TODOs
 
 - Support more currencies
-- Better grammar support
+- Better grammar support (native-speaker review of dictionaries; classical inflection)
 - ~~Add test cases~~

--- a/README.md
+++ b/README.md
@@ -1,55 +1,201 @@
-# Tafgeet-Arabic
+# tafgeet-arabic
 
-An [NPM module](https://www.npmjs.com/package/tafgeet-arabic) to convert currency digits into written Arabic words.
+> Convert numeric currency amounts into written Arabic words — for invoices, receipts, contracts, and legal documents.
 
-## How to use
+[![npm version](https://img.shields.io/npm/v/tafgeet-arabic.svg)](https://www.npmjs.com/package/tafgeet-arabic)
+[![CI](https://github.com/omar-ehab/tafgeet-arabic/actions/workflows/main.yml/badge.svg)](https://github.com/omar-ehab/tafgeet-arabic/actions/workflows/main.yml)
+[![license](https://img.shields.io/npm/l/tafgeet-arabic.svg)](./LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/tafgeet-arabic.svg)](https://www.npmjs.com/package/tafgeet-arabic)
 
-### Install
-
-```sh
-npm install tafgeet-arabic
+```ts
+new Tafgeet('1234.56', 'EGP').parse();
+// → ألف ومائتين وأربعة وثلاثون جنيه مصري وستة وخمسون قرش فقط لا غير
 ```
 
-### Usage
-
-```typescript
-const { Tafgeet } = require("tafgeet-arabic"); // ES5
-import { Tafgeet } from "tafgeet-arabic";      // ES6
-
-const stringText = new Tafgeet(55000051000.2, 'EGP').parse();
-// خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وٱثنين قرش فقط لا غير
-```
-
-## Supported currencies
-
-- SDG (Sudanese Pound)
-- SAR (Saudi Riyal)
-- QAR (Qatari Riyal)
-- AED (Emarati Dirham)
-- EGP (Egyptian Pound) - *Default*
-- KWD (Kuwaiti Dinar)
-- USD (US Dollar)
-- TND (Tunisian Dinar)
-- AUD (Australian Dollar)
-- TRY (Turkish Lira)
-
-## Changelog
-
-See [CHANGELOG.md](./CHANGELOG.md) for release notes. Highlights of **v1.1.0**:
-
-- **3.5–4.7× faster** across all input sizes
-- **52% smaller** install size (test files no longer published)
-- **Bug fixes** for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7), [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8), and the fraction singular/plural rule
-- **KWD (Kuwaiti Dinar)** currency added
-- **Input validation** — bad input throws typed errors instead of silent garbage
-- **TypeScript types** ship in the package and are re-exported from the entry point
+- ⚡ ~900,000 ops/sec — pure JS, zero runtime dependencies
+- 📦 ~6 kB gzipped, ships TypeScript `.d.ts` files
+- 🛡 Strict input validation with typed `TypeError` / `RangeError`
+- 🌍 10 currencies: EGP, SAR, QAR, AED, KWD, USD, AUD, SDG, TND, TRY
 
 ## Requirements
 
 - Node.js **≥ 18.18.0**
 
-## TODOs
+## Install
 
-- Support more currencies
-- Better grammar support (native-speaker review of dictionaries; classical inflection)
-- ~~Add test cases~~
+```sh
+npm install tafgeet-arabic
+```
+
+## Usage
+
+### Quick start
+
+```ts
+// ES Module / TypeScript
+import { Tafgeet } from 'tafgeet-arabic';
+
+// CommonJS
+const { Tafgeet } = require('tafgeet-arabic');
+
+new Tafgeet('1234.56').parse();
+// → 'ألف ومائتين وأربعة وثلاثون جنيه مصري وستة وخمسون قرش فقط لا غير'
+```
+
+> **Tip:** prefer passing the amount as a **string** (`'1234.56'`) over a JS number.
+> JavaScript's `Number` loses precision above 2<sup>53</sup> and can mis-render trailing
+> decimals (`1.1 + 0.2` is `1.3000000000000003`, not `1.3`). The package accepts
+> both, but strings round-trip cleanly.
+
+### Multiple currencies
+
+```ts
+new Tafgeet('500', 'SAR').parse();
+// → 'خمسمائة ريال سعودي فقط لا غير'
+
+new Tafgeet('1.005', 'KWD').parse();  // Kuwaiti Dinar uses 3 decimals
+// → 'واحد دينار كويتي وخمسة فلوس فقط لا غير'
+
+new Tafgeet('1234567', 'USD').parse();
+// → 'مليون ومائتين وأربعة وثلاثون ألف وخمسمائة وسبعة وستون دولار أمريكي فقط لا غير'
+```
+
+### No-currency mode
+
+Pass an empty string to render the number alone, without a currency suffix:
+
+```ts
+new Tafgeet('7564654', '').parse();
+// → 'سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون فقط لا غير'
+```
+
+### Error handling
+
+Invalid input throws a typed error rather than producing garbage output:
+
+```ts
+try {
+  new Tafgeet(-100, 'EGP');
+} catch (err) {
+  // err instanceof RangeError
+  // err.message === 'Tafgeet: amount must be non-negative, got -100'
+}
+
+try {
+  new Tafgeet(1, 'XYZ');
+} catch (err) {
+  // err instanceof Error
+  // err.message === 'Tafgeet: unknown currency "XYZ". Supported: SDG, SAR, QAR, AED, EGP, KWD, USD, AUD, TND, TRY'
+}
+```
+
+See [API → Errors](#errors) for the full list.
+
+### TypeScript
+
+All public types are re-exported from the package entry point:
+
+```ts
+import { Tafgeet, Currency, Currencies, NumberProperties } from 'tafgeet-arabic';
+
+const cur: Currency = {
+  singular: 'دينار',
+  plural: 'دنانير',
+  fraction: 'فلس',
+  fractions: 'فلوس',
+  decimals: 3,
+};
+```
+
+## API
+
+### `new Tafgeet(amount, currency?)`
+
+Creates a new `Tafgeet` instance. The constructor validates the input
+eagerly and throws if anything is malformed.
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `amount` | `string \| number` | — | Integer part must be **≥ 1** and **≤ 15 digits**. Pass a string to avoid float precision loss. |
+| `currency` | `string` | `'EGP'` | ISO-style code from the [supported currencies](#supported-currencies), or `''` for no-currency mode. |
+
+### `.parse(): string`
+
+Renders the full amount as Arabic words, including the currency suffix
+and the closing `فقط لا غير`.
+
+```ts
+new Tafgeet('123.45', 'EGP').parse();
+// → 'مائة وثلاثة وعشرون جنيه مصري وخمسة وأربعون قرش فقط لا غير'
+```
+
+### `.read(d: number): string`
+
+Renders a number in `0–999` as Arabic words, with **no** column suffix and
+**no** currency. Useful for custom formatting.
+
+```ts
+const t = new Tafgeet('1');   // any instance
+t.read(42);  // → 'ٱثنين وأربعون'
+t.read(100); // → 'مائة'
+t.read(999); // → 'تسعمائة وتسعة وتسعون'
+```
+
+### Errors
+
+| Class | When |
+|---|---|
+| `TypeError` | `amount` is `null`, `undefined`, the wrong type, a non-numeric string, empty string, or scientific notation. Also thrown when `currency` is not a string. |
+| `RangeError` | `amount` is `NaN`, `Infinity`, negative, zero (integer part < 1), or has more than 15 integer digits. |
+| `Error` | `currency` is not one of the supported codes. |
+
+## Supported currencies
+
+| Code | Currency | Decimals |
+|---|---|---|
+| `EGP` *(default)* | Egyptian Pound — جنيه مصري | 2 |
+| `SAR` | Saudi Riyal — ريال سعودي | 2 |
+| `QAR` | Qatari Riyal — ريال قطري | 2 |
+| `AED` | Emarati Dirham — درهم أماراتي | 2 |
+| `KWD` | Kuwaiti Dinar — دينار كويتي | 3 |
+| `USD` | US Dollar — دولار أمريكي | 2 |
+| `AUD` | Australian Dollar — دولار أسترالي | 2 |
+| `SDG` | Sudanese Pound — جنيه سوداني | 2 |
+| `TND` | Tunisian Dinar — دينار تونسي | 3 |
+| `TRY` | Turkish Lira — ليرة تركية | 2 |
+
+Missing a currency? [Open an issue](https://github.com/omar-ehab/tafgeet-arabic/issues/new) or send a PR.
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md). Highlights of **v1.1.0**:
+
+- **3.5–4.7× faster** across all input sizes
+- **52% smaller** install (test files no longer shipped)
+- Fixes for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7), [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8), and the fraction singular/plural rule
+- **KWD (Kuwaiti Dinar)** added
+- **Input validation** with typed errors
+- TypeScript types now ship and are re-exported from the package root
+
+## Roadmap
+
+- More currencies (BHD, OMR, JOD, IQD, LBP, MAD, DZD, …)
+- Native-speaker grammar review of dictionaries (dual form for 2, classical inflection for 11–99)
+- Optional functional API: `tafgeet(amount, currency?)` alongside the class
+
+## Contributing
+
+PRs and issues welcome. To set up locally:
+
+```sh
+git clone https://github.com/omar-ehab/tafgeet-arabic
+cd tafgeet-arabic
+npm install
+npm test               # 107 mocha tests
+npm run lint           # ESLint
+npm run test:js-compat # plain-JS smoke test against built dist/
+```
+
+## License
+
+[MIT](./LICENSE) © Omar Ehab

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tafgeet-arabic",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -20,6 +20,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.60.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Converts currency digits into written Arabic words",
   "main": "dist/src/index.js",
   "scripts": {


### PR DESCRIPTION
Release prep for v1.1.0. Two commits:

1. `chore: release 1.1.0` — bumps `package.json` 1.0.11 → 1.1.0, adds the v1.1.0 entry to `CHANGELOG.md`.
2. `docs: comprehensive README overhaul for 1.1.0` — fixes 2 incorrectness bugs, adds API reference + error-handling + TypeScript + badges. Every code example verified against actual output.

After merge, follow the publish flow below.

**Verified:**
- ✅ `npm run lint` — 0 violations
- ✅ `npm run format:check` — clean
- ✅ `npm test` — 107 passing
- ✅ `npm run test:js-compat` — passed
- ✅ `npm audit` — 0 vulnerabilities
- ✅ Every README example output verified byte-identical against the built package
- ✅ `npm pack --dry-run` → 7.6 kB tarball / 25.2 kB unpacked