### PR TITLE
feat: add CurrencyCode union type + SUPPORTED_CURRENCIES runtime export

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { Currencies, NumberProperties } from './types';
+import { CurrencyCode, Currencies, NumberProperties } from './types';
 
 export const currencies: Currencies = {
   SDG: {
@@ -74,6 +74,29 @@ export const currencies: Currencies = {
 };
 
 export const columns: readonly string[] = ['trillions', 'billions', 'millions', 'thousands'];
+
+/**
+ * Runtime-accessible list of built-in currency codes. Useful for
+ * iterating supported currencies or validating user input without
+ * a try/catch around the constructor.
+ *
+ *   if (SUPPORTED_CURRENCIES.includes(userInput as CurrencyCode)) { ... }
+ *
+ * Kept in sync with the `Currencies` interface; if you ever bundle
+ * a new currency, add it here AND to `Currencies` AND to `currencies`.
+ */
+export const SUPPORTED_CURRENCIES: readonly CurrencyCode[] = Object.freeze([
+  'SDG',
+  'SAR',
+  'QAR',
+  'AED',
+  'EGP',
+  'KWD',
+  'USD',
+  'AUD',
+  'TND',
+  'TRY',
+]);
 
 // -- Number-word dictionaries -------------------------------------------------
 // Indexed by the digit value (1-9 for ones, etc.) so callers can do

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
 import { COLUMN_PROPERTIES, columns, currencies, HUNDREDS, ONES, TEENS, TENS } from './constants';
+import { CurrencyInput } from './types';
 
-// Re-export public types so consumers can import them directly:
-//   import { Tafgeet, Currency, Currencies, NumberProperties } from 'tafgeet-arabic';
-export type { Currency, Currencies, NumberProperties } from './types';
+// Re-export public types + runtime helpers so consumers can import them
+// directly:
+//
+//   import { Tafgeet, SUPPORTED_CURRENCIES } from 'tafgeet-arabic';
+//   import type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties } from 'tafgeet-arabic';
+export type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties } from './types';
+export { SUPPORTED_CURRENCIES } from './constants';
 
 export class Tafgeet {
   private currency: string;
@@ -10,7 +15,7 @@ export class Tafgeet {
   private fraction: number;
   private digit: number;
 
-  constructor(digit: string | number, currency: string = 'EGP') {
+  constructor(digit: string | number, currency: CurrencyInput = 'EGP') {
     Tafgeet.validateInput(digit, currency);
     this.currency = currency;
     this.splitted = digit.toString().split('.');

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,3 +50,28 @@ export interface Currencies {
   TND: Currency;
   TRY: Currency;
 }
+
+/**
+ * Union of all built-in currency code strings. Use this in your own
+ * type signatures to enforce a known code at compile time:
+ *
+ *   function quote(amount: number, code: CurrencyCode) { ... }
+ *
+ * Derived from `Currencies` via `keyof`, so adding a currency to
+ * the `Currencies` interface automatically extends `CurrencyCode`.
+ */
+export type CurrencyCode = keyof Currencies;
+
+/**
+ * The Tafgeet constructor's currency parameter accepts:
+ *   - a known CurrencyCode      — IDE autocompletes all valid codes
+ *   - `''` (empty string)       — no-currency mode (number only)
+ *   - any other string          — accepted for forward compatibility,
+ *                                 but the runtime validator will reject
+ *                                 anything not registered in `currencies`
+ *
+ * The `(string & {})` intersection is a deliberate TypeScript trick that
+ * preserves autocomplete for the literal union while still permitting
+ * arbitrary string inputs (see microsoft/TypeScript#29729).
+ */
+export type CurrencyInput = CurrencyCode | '' | (string & {});

--- a/test/currency-code.spec.ts
+++ b/test/currency-code.spec.ts
@@ -1,0 +1,71 @@
+import { assert } from 'chai';
+
+import { SUPPORTED_CURRENCIES, Tafgeet, type CurrencyCode } from '../src';
+
+describe('CurrencyCode + SUPPORTED_CURRENCIES (1.2.0)', () => {
+  describe('SUPPORTED_CURRENCIES runtime export', () => {
+    it('is an array of all 10 built-in codes', () => {
+      assert.lengthOf(SUPPORTED_CURRENCIES, 10);
+      assert.includeMembers(
+        [...SUPPORTED_CURRENCIES],
+        ['EGP', 'SAR', 'QAR', 'AED', 'KWD', 'USD', 'AUD', 'SDG', 'TND', 'TRY'],
+      );
+    });
+
+    it('is frozen — cannot be mutated', () => {
+      assert.throws(() => {
+        (SUPPORTED_CURRENCIES as CurrencyCode[]).push('BTC' as CurrencyCode);
+      }, /Cannot add property|object is not extensible/);
+    });
+
+    it('every code is round-trip valid as a Tafgeet currency arg', () => {
+      for (const code of SUPPORTED_CURRENCIES) {
+        const text = new Tafgeet('1', code).parse();
+        assert.isString(text);
+        assert.notInclude(text, 'undefined', `${code} produced "undefined" in output`);
+        assert.include(text, 'فقط لا غير', `${code} missing closing فقط لا غير`);
+      }
+    });
+  });
+
+  describe('CurrencyCode type (compile-time)', () => {
+    // These tests pass if they COMPILE — the runtime assertion is incidental.
+    // The whole point of `CurrencyCode` is that TS catches typos at build time
+    // (e.g. `'EPG'` instead of `'EGP'`).
+    it('accepts a CurrencyCode-typed variable', () => {
+      const code: CurrencyCode = 'EGP';
+      const text = new Tafgeet('1', code).parse();
+      assert.equal(text, 'واحد جنيه مصري فقط لا غير');
+    });
+
+    it('accepts an arbitrary string at the type level (forward compat)', () => {
+      // The `(string & {})` trick in CurrencyInput preserves autocomplete
+      // for the literal union while still allowing arbitrary strings —
+      // useful for codes coming from APIs / user input that the type
+      // system can't know about.
+      const code: string = 'EGP';
+      const text = new Tafgeet('1', code).parse();
+      assert.equal(text, 'واحد جنيه مصري فقط لا غير');
+    });
+
+    it('runtime still rejects unknown codes', () => {
+      // The type may allow `(string & {})` for forward compat, but the
+      // validator still throws on unregistered codes.
+      assert.throws(() => new Tafgeet('1', 'BTC'), /unknown currency "BTC"/);
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    it('plain string literal still works as before', () => {
+      assert.equal(new Tafgeet('1', 'EGP').parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+
+    it('empty string (no-currency mode) still works as before', () => {
+      assert.equal(new Tafgeet('1', '').parse(), 'واحد فقط لا غير');
+    });
+
+    it('default EGP still applies when currency omitted', () => {
+      assert.equal(new Tafgeet('1').parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+  });
+});


### PR DESCRIPTION
PR 3 of the v1.2.0 series. Three new public exports, fully backward-compatible.

## New exports

```ts
import { Tafgeet, SUPPORTED_CURRENCIES } from 'tafgeet-arabic';
import type { CurrencyCode, CurrencyInput } from 'tafgeet-arabic';
```

### `type CurrencyCode`

```ts
type CurrencyCode = 'SDG' | 'SAR' | 'QAR' | 'AED' | 'EGP' | 'KWD' | 'USD' | 'AUD' | 'TND' | 'TRY';
```

**Single source of truth** — derived from `keyof Currencies`. Adding a currency to the `Currencies` interface automatically extends the union, with no manual list to keep in sync.

```ts
// IDE autocompletes all 10 codes.
const code: CurrencyCode = 'EGP';
new Tafgeet('100', code);

// Typos caught at compile time:
const bad: CurrencyCode = 'EPG'; // ❌ TS2322: Type '"EPG"' is not assignable to type 'CurrencyCode'
```

### `type CurrencyInput`

The constructor's currency parameter type:

```ts
type CurrencyInput = CurrencyCode | '' | (string & {});
```

The `(string & {})` intersection is a deliberate TypeScript trick ([microsoft/TypeScript#29729](https://github.com/microsoft/TypeScript/issues/29729)) that **preserves autocomplete** for the literal union while still permitting arbitrary strings — useful for codes coming from APIs or user input that the type system can't know about. Runtime validation still rejects unregistered codes.

### `const SUPPORTED_CURRENCIES`

```ts
SUPPORTED_CURRENCIES: readonly CurrencyCode[]
```

Frozen runtime array. Useful for iterating supported currencies or validating input without a try/catch:

```ts
if (SUPPORTED_CURRENCIES.includes(userInput as CurrencyCode)) {
  const text = new Tafgeet(amount, userInput as CurrencyCode).parse();
}
```

## Constructor signature change

```diff
- constructor(digit: string | number, currency: string = 'EGP')
+ constructor(digit: string | number, currency: CurrencyInput = 'EGP')
```

`CurrencyInput` is assignable from any string, so **any code the old signature accepted still typechecks unchanged**.

## Backward compatibility

| | Status |
|---|---|
| Old `string` calls (`new Tafgeet('1', 'EGP')`) | ✅ Type-checks unchanged |
| Empty-string no-currency mode (`''`) | ✅ Explicit in the union, type-checks unchanged |
| Arbitrary strings from APIs | ✅ Allowed by `(string & {})` |
| Runtime validator | ✅ Unchanged — still throws on unregistered codes |
| All 371 prior tests | ✅ Pass byte-identical |
| CJS + ESM smoke tests | ✅ Both pass |

## Tests added

9 new tests covering:
- `SUPPORTED_CURRENCIES` is the right length, has the right members, is frozen
- Every code in `SUPPORTED_CURRENCIES` produces a valid output (no `"undefined"` strings)
- `CurrencyCode`-typed variable works
- `string`-typed variable still works (forward compat)
- Runtime still rejects unknown codes
- 3 explicit backward-compat regressions (plain string literal, empty string, default)

**Total: 380 tests pass (was 371).**