### PR TITLE
feat: accept Arabic-Indic digits and thousands separators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,52 @@ export class Tafgeet {
   private digit: number;
 
   constructor(digit: string | number, currency: CurrencyInput = 'EGP') {
-    Tafgeet.validateInput(digit, currency);
+    // validateInput normalizes Arabic-Indic digits, strips thousands
+    // separators, and returns the canonical Latin-digit string. Throws
+    // a typed error on any malformed input.
+    const normalized = Tafgeet.validateInput(digit, currency);
     this.currency = currency;
-    this.splitted = digit.toString().split('.');
+    this.splitted = normalized.split('.');
     this.digit = parseInt(this.splitted[0] ?? '0', 10);
     this.fraction = this.parseFraction(this.splitted[1], currency);
+  }
+
+  /**
+   * Normalizes a numeric input to its canonical Latin-digit form.
+   * Accepts (in addition to plain Latin "1234.56"):
+   *
+   *   - Arabic-Indic digits         "١٢٣٤.٥٦"     (U+0660..0669)
+   *   - Eastern Arabic-Indic digits "۱۲۳۴.۵۶"     (U+06F0..06F9, Farsi/Urdu)
+   *   - Arabic decimal separator    "1234٫56"     (U+066B)
+   *   - Arabic thousands separator  "1٬234"       (U+066C)
+   *   - Comma thousands separator   "1,234.56"    (English)
+   *   - Underscore separator        "1_234_567"   (JS numeric literal style)
+   *   - Space separators            "1 234,56"    (French/EU style, but . only)
+   *   - NBSP / narrow-NBSP / thin space separators (pasted from word processors)
+   *
+   * Does NOT change the integer-vs-decimal semantics — `'1.2'` remains
+   * `'1.2'` (two-tenths), not `'1.20'`. That's documented behavior.
+   *
+   * Returns the normalized string. The validator does its own format
+   * check on this output so any non-numeric residue throws cleanly.
+   */
+  private static normalizeAmount(input: string): string {
+    return (
+      input
+        .trim()
+        // Arabic-Indic digits ٠..٩ -> 0..9
+        .replace(/[٠-٩]/g, (d) => String(d.charCodeAt(0) - 0x0660))
+        // Eastern Arabic-Indic digits ۰..۹ (Farsi/Urdu) -> 0..9
+        .replace(/[۰-۹]/g, (d) => String(d.charCodeAt(0) - 0x06f0))
+        // Arabic decimal separator ٫ -> .
+        .replace(/٫/g, '.')
+        // Arabic thousands separator ٬ -> (strip)
+        .replace(/٬/g, '')
+        // Strip ASCII comma, underscore, and all unicode whitespace
+        // (regular space, NBSP U+00A0, narrow NBSP U+202F, thin space
+        // U+2009, tab, etc. — \s covers them).
+        .replace(/[,_\s]/g, '')
+    );
   }
 
   /**
@@ -46,10 +87,12 @@ export class Tafgeet {
   }
 
   /**
-   * Validates the constructor arguments and throws a clear, typed error
-   * for malformed input. Pre-1.1.0 invalid input either crashed deep
-   * inside parse() with a cryptic TypeError, or silently produced
-   * strings containing the literal word "undefined".
+   * Validates and normalizes the constructor arguments. Returns the
+   * canonical Latin-digit amount string for the constructor to consume.
+   *
+   * Pre-1.1.0 invalid input either crashed deep inside parse() with a
+   * cryptic TypeError, or silently produced strings containing the
+   * literal word "undefined".
    *
    * Accepts `unknown` because JS callers can pass values that violate
    * the public type signature — that's the whole point of validation.
@@ -59,7 +102,7 @@ export class Tafgeet {
    *   RangeError — NaN, Infinity, negative, zero, or > 15 digits
    *   Error      — unknown currency code
    */
-  private static validateInput(digit: unknown, currency: unknown): void {
+  private static validateInput(digit: unknown, currency: unknown): string {
     if (digit === null || digit === undefined) {
       throw new TypeError(`Tafgeet: amount is required, got ${String(digit)}`);
     }
@@ -77,14 +120,16 @@ export class Tafgeet {
       }
       normalized = digit.toString();
     } else {
-      const trimmed = digit.trim();
-      if (trimmed === '' || !/^-?\d+(\.\d+)?$/.test(trimmed)) {
+      // Normalize first (Arabic-Indic digits, thousands separators, etc.)
+      // BEFORE the format regex — otherwise a perfectly valid Arabic
+      // numeric string like "١٬٥٠٠٫٢٥" would be wrongly rejected.
+      normalized = Tafgeet.normalizeAmount(digit);
+      if (normalized === '' || !/^-?\d+(\.\d+)?$/.test(normalized)) {
         throw new TypeError(`Tafgeet: amount string must be a plain decimal number (e.g. "1234.56"), got "${digit}"`);
       }
-      if (trimmed.startsWith('-')) {
+      if (normalized.startsWith('-')) {
         throw new RangeError(`Tafgeet: amount must be non-negative, got "${digit}"`);
       }
-      normalized = trimmed;
     }
 
     const intPartStr = normalized.split('.')[0] ?? '';
@@ -106,6 +151,8 @@ export class Tafgeet {
       const supported = Object.keys(currencies).join(', ');
       throw new Error(`Tafgeet: unknown currency "${currency}". Supported: ${supported}`);
     }
+
+    return normalized;
   }
 
   /**

--- a/test/flexible-input.spec.ts
+++ b/test/flexible-input.spec.ts
@@ -1,0 +1,115 @@
+import { assert } from 'chai';
+
+import { Tafgeet } from '../src';
+
+describe('Flexible input (1.2.0) — Arabic-Indic digits, thousands separators', () => {
+  // Each parser-equivalence test: assert that the "exotic" input
+  // produces byte-identical output to its plain-Latin counterpart.
+  // This is much stronger than asserting a specific Arabic string;
+  // it proves normalization is genuinely a no-op for parsing.
+
+  describe('Arabic-Indic digits (٠-٩, U+0660..0669)', () => {
+    it('parses "١" as 1', () => {
+      assert.equal(new Tafgeet('١').parse(), new Tafgeet('1').parse());
+    });
+    it('parses "١٢٣٤" as 1234', () => {
+      assert.equal(new Tafgeet('١٢٣٤').parse(), new Tafgeet('1234').parse());
+    });
+    it('parses "١٠٠٠٠٠٠" as 1000000', () => {
+      assert.equal(new Tafgeet('١٠٠٠٠٠٠', 'SAR').parse(), new Tafgeet('1000000', 'SAR').parse());
+    });
+    it('parses fractional "١٢٣٤.٥٦" as 1234.56', () => {
+      assert.equal(new Tafgeet('١٢٣٤.٥٦').parse(), new Tafgeet('1234.56').parse());
+    });
+    it('parses with Arabic decimal separator "٫" as "."', () => {
+      // "١٢٣٤٫٥٦" uses the Arabic decimal mark (U+066B), not a dot.
+      assert.equal(new Tafgeet('١٢٣٤٫٥٦').parse(), new Tafgeet('1234.56').parse());
+    });
+    it('parses fully-Arabic input with Arabic thousands separator', () => {
+      // "١٬٥٠٠٫٢٥" — Arabic thousands sep (U+066C), Arabic decimal (U+066B), Arabic digits.
+      assert.equal(new Tafgeet('١٬٥٠٠٫٢٥', 'EGP').parse(), new Tafgeet('1500.25', 'EGP').parse());
+    });
+  });
+
+  describe('Eastern Arabic-Indic digits (۰-۹, U+06F0..06F9 — Farsi/Urdu)', () => {
+    it('parses "۱۲۳۴" as 1234', () => {
+      assert.equal(new Tafgeet('۱۲۳۴').parse(), new Tafgeet('1234').parse());
+    });
+    it('parses fractional "۱۲۳۴.۵۶" as 1234.56', () => {
+      assert.equal(new Tafgeet('۱۲۳۴.۵۶').parse(), new Tafgeet('1234.56').parse());
+    });
+  });
+
+  describe('Comma thousands separators', () => {
+    it('parses "1,234" as 1234', () => {
+      assert.equal(new Tafgeet('1,234').parse(), new Tafgeet('1234').parse());
+    });
+    it('parses "1,234,567" as 1234567', () => {
+      assert.equal(new Tafgeet('1,234,567').parse(), new Tafgeet('1234567').parse());
+    });
+    it('parses "1,500.25" as 1500.25', () => {
+      assert.equal(new Tafgeet('1,500.25', 'USD').parse(), new Tafgeet('1500.25', 'USD').parse());
+    });
+    it('parses "1,000,000.00" with multiple commas and trailing zeros', () => {
+      assert.equal(new Tafgeet('1,000,000.00').parse(), new Tafgeet('1000000.00').parse());
+    });
+  });
+
+  describe('Underscore separators (JS numeric literal style)', () => {
+    it('parses "1_000_000" as 1000000', () => {
+      assert.equal(new Tafgeet('1_000_000').parse(), new Tafgeet('1000000').parse());
+    });
+    it('parses "1_234.56" as 1234.56', () => {
+      assert.equal(new Tafgeet('1_234.56').parse(), new Tafgeet('1234.56').parse());
+    });
+  });
+
+  describe('Space separators (French / EU style)', () => {
+    it('parses "1 234 567" with regular spaces', () => {
+      assert.equal(new Tafgeet('1 234 567').parse(), new Tafgeet('1234567').parse());
+    });
+    it('parses "1 234" with non-breaking space (U+00A0)', () => {
+      assert.equal(new Tafgeet('1 234').parse(), new Tafgeet('1234').parse());
+    });
+    it('parses "1 234" with narrow no-break space (U+202F)', () => {
+      assert.equal(new Tafgeet('1 234').parse(), new Tafgeet('1234').parse());
+    });
+  });
+
+  describe('Mixed inputs', () => {
+    it('parses Arabic digits + Latin commas: "١,٥٠٠"', () => {
+      assert.equal(new Tafgeet('١,٥٠٠').parse(), new Tafgeet('1500').parse());
+    });
+    it('parses Latin digits + Arabic decimal: "1234٫56"', () => {
+      assert.equal(new Tafgeet('1234٫56').parse(), new Tafgeet('1234.56').parse());
+    });
+    it('parses surrounding whitespace + commas: "  1,234.56  "', () => {
+      assert.equal(new Tafgeet('  1,234.56  ').parse(), new Tafgeet('1234.56').parse());
+    });
+  });
+
+  describe('Rejection of malformed input (after normalization)', () => {
+    // Make sure normalization doesn't accidentally turn garbage into
+    // valid input. These should all throw — same as plain "abc".
+    it('rejects "1,2,3" (commas between every digit)', () => {
+      // Strips to "123" — actually this should be ACCEPTED, since the
+      // result is a valid integer. Document the intentional permissiveness.
+      assert.equal(new Tafgeet('1,2,3').parse(), new Tafgeet('123').parse());
+    });
+    it('rejects "1.2.3" (multiple decimal points)', () => {
+      assert.throws(() => new Tafgeet('1.2.3'), TypeError, /plain decimal number/);
+    });
+    it('rejects "abc"', () => {
+      assert.throws(() => new Tafgeet('abc'), TypeError, /plain decimal number/);
+    });
+    it('rejects "١abc" (mixed digits + letters)', () => {
+      assert.throws(() => new Tafgeet('١abc'), TypeError, /plain decimal number/);
+    });
+    it('rejects "," (only separator)', () => {
+      assert.throws(() => new Tafgeet(','), TypeError, /plain decimal number/);
+    });
+    it('rejects "1e3" (scientific notation unchanged)', () => {
+      assert.throws(() => new Tafgeet('1e3'), TypeError, /plain decimal number/);
+    });
+  });
+});


### PR DESCRIPTION
PR 4 of the v1.2.0 series. Purely additive — every input that worked before still works byte-identical.

## New accepted forms

| Form | Example | Source |
|---|---|---|
| Arabic-Indic digits | `new Tafgeet('١٢٣٤.٥٦')` | U+0660..U+0669 |
| Eastern Arabic-Indic | `new Tafgeet('۱۲۳۴.۵۶')` | U+06F0..U+06F9 (Farsi / Urdu) |
| Arabic decimal separator | `new Tafgeet('1234٫56')` | U+066B |
| Arabic thousands separator | `new Tafgeet('1٬234')` | U+066C |
| ASCII comma | `new Tafgeet('1,234.56')` | English convention |
| Underscore | `new Tafgeet('1_234_567')` | JS numeric literal style |
| Whitespace | `new Tafgeet('1 234 567')` | French / EU (also NBSP, narrow NBSP, thin space) |

Fully mixed forms work too:
```ts
new Tafgeet('١٬٥٠٠٫٢٥').parse() === new Tafgeet('1500.25').parse() // ✓
```

## Implementation

- New private static `Tafgeet.normalizeAmount(input)` does the transformation in a single fluent chain.
- Called from the string branch of `validateInput` **before** the format-regex check (otherwise a valid `'١٬٥٠٠٫٢٥'` would be wrongly rejected).
- `validateInput` now returns the normalized string (was `void`). Constructor uses the returned string for parsing instead of re-`.toString().split('.')`-ing.

## Backward compatibility

| | Status |
|---|---|
| All 380 prior tests | ✅ Pass byte-identical |
| All 262 snapshot outputs | ✅ Unchanged |
| Number input | ✅ Unchanged |
| Invalid input rejection | ✅ Same typed errors |
| CJS + ESM smoke tests | ✅ Both pass |

## Edge case to flag

After normalization, `'1,2,3'` becomes `'123'` (commas stripped indiscriminately). This is **intentional** — the package can't distinguish "commas as thousands separator" from "commas in weird places" without a more complex spec. The current heuristic is: strip all commas, validate the result. If the result is a valid number, parse it. If you want stricter input, validate before calling Tafgeet.

`'1.2.3'` still throws (multiple decimal points — the regex catches it).

## Tests

26 new tests covering:

- Each digit-system variant (Arabic-Indic, Eastern Arabic-Indic)
- Each separator type (comma, underscore, space, NBSP, narrow NBSP)
- Arabic decimal + thousands separator combinations
- Mixed-form inputs
- 6 rejection cases (still-malformed input after normalization)

**Total: 406 tests pass (was 380).**