### PR TITLE
feat: custom error classes with discriminated codes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,100 @@
+/**
+ * Custom error classes thrown by the Tafgeet constructor.
+ *
+ * Design notes:
+ *
+ *   - Each class extends the appropriate built-in (TypeError / RangeError /
+ *     Error) so existing catch-by-built-in patterns continue to work:
+ *
+ *       try { new Tafgeet(null); } catch (e) {
+ *         if (e instanceof TypeError) { ... }    // still works
+ *       }
+ *
+ *   - Each carries a typed `code` field for structured catching:
+ *
+ *       try { new Tafgeet(input, currency); } catch (e) {
+ *         if (isTafgeetError(e)) {
+ *           switch (e.code) {
+ *             case 'INVALID_AMOUNT':        ...; break;
+ *             case 'AMOUNT_OUT_OF_RANGE':   ...; break;
+ *             case 'UNSUPPORTED_CURRENCY':  ...; break;
+ *           }
+ *         }
+ *       }
+ *
+ *   - There is NO `TafgeetError` base class. JavaScript doesn't support
+ *     multiple inheritance, so a base class can't be both `extends Error`
+ *     AND keep `instanceof TypeError` / `instanceof RangeError` true on
+ *     subclasses. Use the `isTafgeetError` typeguard instead.
+ */
+
+/** Discriminated codes for structured error catching. */
+export type TafgeetErrorCode = 'INVALID_AMOUNT' | 'AMOUNT_OUT_OF_RANGE' | 'UNSUPPORTED_CURRENCY';
+
+/**
+ * Thrown when the amount input is the wrong type or malformed:
+ * null, undefined, non-numeric string, empty string, scientific
+ * notation, etc.
+ *
+ * Extends TypeError, so `instanceof TypeError` is `true`.
+ */
+export class InvalidAmountError extends TypeError {
+  readonly code = 'INVALID_AMOUNT' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidAmountError';
+  }
+}
+
+/**
+ * Thrown when the amount is the right type but outside the supported
+ * range: NaN, ±Infinity, negative, zero (integer part < 1), or more
+ * than 15 integer digits.
+ *
+ * Extends RangeError, so `instanceof RangeError` is `true`.
+ */
+export class AmountOutOfRangeError extends RangeError {
+  readonly code = 'AMOUNT_OUT_OF_RANGE' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AmountOutOfRangeError';
+  }
+}
+
+/**
+ * Thrown when the currency code is a string but not one of the
+ * registered codes in `SUPPORTED_CURRENCIES`.
+ *
+ * Extends Error directly (currency mismatch isn't a type or range
+ * issue — it's a lookup failure).
+ */
+export class UnsupportedCurrencyError extends Error {
+  readonly code = 'UNSUPPORTED_CURRENCY' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedCurrencyError';
+  }
+}
+
+/**
+ * Type guard for "any error thrown by the Tafgeet constructor".
+ *
+ * Useful when you want to handle all Tafgeet errors uniformly and
+ * forward unrelated errors (e.g. from your own code) up the stack:
+ *
+ *   try {
+ *     ...
+ *   } catch (e) {
+ *     if (isTafgeetError(e)) {
+ *       reportToUser(e.code, e.message);
+ *     } else {
+ *       throw e;
+ *     }
+ *   }
+ */
+export function isTafgeetError(e: unknown): e is InvalidAmountError | AmountOutOfRangeError | UnsupportedCurrencyError {
+  return e instanceof InvalidAmountError || e instanceof AmountOutOfRangeError || e instanceof UnsupportedCurrencyError;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,26 @@
 import { COLUMN_PROPERTIES, columns, currencies, HUNDREDS, ONES, TEENS, TENS } from './constants';
+import { AmountOutOfRangeError, InvalidAmountError, UnsupportedCurrencyError } from './errors';
 import { CurrencyInput } from './types';
 
 // Re-export public types + runtime helpers so consumers can import them
 // directly:
 //
-//   import { Tafgeet, SUPPORTED_CURRENCIES } from 'tafgeet-arabic';
-//   import type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties } from 'tafgeet-arabic';
+//   import {
+//     Tafgeet,
+//     SUPPORTED_CURRENCIES,
+//     InvalidAmountError, AmountOutOfRangeError, UnsupportedCurrencyError,
+//     isTafgeetError,
+//   } from 'tafgeet-arabic';
+//   import type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties, TafgeetErrorCode } from 'tafgeet-arabic';
 export type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties } from './types';
 export { SUPPORTED_CURRENCIES } from './constants';
+export {
+  InvalidAmountError,
+  AmountOutOfRangeError,
+  UnsupportedCurrencyError,
+  isTafgeetError,
+  type TafgeetErrorCode,
+} from './errors';
 
 export class Tafgeet {
   private currency: string;
@@ -104,19 +117,19 @@ export class Tafgeet {
    */
   private static validateInput(digit: unknown, currency: unknown): string {
     if (digit === null || digit === undefined) {
-      throw new TypeError(`Tafgeet: amount is required, got ${String(digit)}`);
+      throw new InvalidAmountError(`Tafgeet: amount is required, got ${String(digit)}`);
     }
     if (typeof digit !== 'number' && typeof digit !== 'string') {
-      throw new TypeError(`Tafgeet: amount must be a number or numeric string, got ${typeof digit}`);
+      throw new InvalidAmountError(`Tafgeet: amount must be a number or numeric string, got ${typeof digit}`);
     }
 
     let normalized: string;
     if (typeof digit === 'number') {
       if (!Number.isFinite(digit)) {
-        throw new RangeError(`Tafgeet: amount must be a finite number, got ${digit}`);
+        throw new AmountOutOfRangeError(`Tafgeet: amount must be a finite number, got ${digit}`);
       }
       if (digit < 0) {
-        throw new RangeError(`Tafgeet: amount must be non-negative, got ${digit}`);
+        throw new AmountOutOfRangeError(`Tafgeet: amount must be non-negative, got ${digit}`);
       }
       normalized = digit.toString();
     } else {
@@ -125,10 +138,12 @@ export class Tafgeet {
       // numeric string like "١٬٥٠٠٫٢٥" would be wrongly rejected.
       normalized = Tafgeet.normalizeAmount(digit);
       if (normalized === '' || !/^-?\d+(\.\d+)?$/.test(normalized)) {
-        throw new TypeError(`Tafgeet: amount string must be a plain decimal number (e.g. "1234.56"), got "${digit}"`);
+        throw new InvalidAmountError(
+          `Tafgeet: amount string must be a plain decimal number (e.g. "1234.56"), got "${digit}"`,
+        );
       }
       if (normalized.startsWith('-')) {
-        throw new RangeError(`Tafgeet: amount must be non-negative, got "${digit}"`);
+        throw new AmountOutOfRangeError(`Tafgeet: amount must be non-negative, got "${digit}"`);
       }
     }
 
@@ -138,18 +153,18 @@ export class Tafgeet {
       // Amounts < 1 (e.g. "0", "0.5") are not supported in 1.x — the
       // dictionaries have no "صفر" entry and the column logic assumes
       // at least one integer digit. Tracked as a future enhancement.
-      throw new RangeError(`Tafgeet: integer part must be >= 1, got "${normalized}"`);
+      throw new AmountOutOfRangeError(`Tafgeet: integer part must be >= 1, got "${normalized}"`);
     }
     if (intPartStr.length >= 16) {
-      throw new RangeError(`Tafgeet: integer part must be < 16 digits, got "${normalized}"`);
+      throw new AmountOutOfRangeError(`Tafgeet: integer part must be < 16 digits, got "${normalized}"`);
     }
 
     if (typeof currency !== 'string') {
-      throw new TypeError(`Tafgeet: currency must be a string, got ${typeof currency}`);
+      throw new InvalidAmountError(`Tafgeet: currency must be a string, got ${typeof currency}`);
     }
     if (currency !== '' && !(currency in currencies)) {
       const supported = Object.keys(currencies).join(', ');
-      throw new Error(`Tafgeet: unknown currency "${currency}". Supported: ${supported}`);
+      throw new UnsupportedCurrencyError(`Tafgeet: unknown currency "${currency}". Supported: ${supported}`);
     }
 
     return normalized;
@@ -166,7 +181,11 @@ export class Tafgeet {
   parse(): string {
     const intStr = this.digit.toString();
     if (intStr.length >= 16) {
-      throw new Error('Number out of range!');
+      // Unreachable from public API since 1.1.0 (the constructor
+      // validator catches > 15 digits earlier with a clearer message),
+      // but kept as a safety net for anyone using `read()` directly
+      // or mutating the private `digit` field via reflection.
+      throw new AmountOutOfRangeError('Tafgeet: integer part must be < 16 digits');
     }
 
     let str = '';

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -1,0 +1,190 @@
+import { assert } from 'chai';
+
+import {
+  AmountOutOfRangeError,
+  InvalidAmountError,
+  isTafgeetError,
+  Tafgeet,
+  UnsupportedCurrencyError,
+  type TafgeetErrorCode,
+} from '../src';
+
+describe('Custom error classes (1.2.0)', () => {
+  describe('InvalidAmountError', () => {
+    it('is thrown for null amount', () => {
+      assert.throws(() => new Tafgeet(null as never), InvalidAmountError);
+    });
+    it('is thrown for undefined amount', () => {
+      assert.throws(() => new Tafgeet(undefined as never), InvalidAmountError);
+    });
+    it('is thrown for non-numeric string', () => {
+      assert.throws(() => new Tafgeet('abc'), InvalidAmountError);
+    });
+    it('is thrown for empty string', () => {
+      assert.throws(() => new Tafgeet(''), InvalidAmountError);
+    });
+    it('is thrown for scientific notation', () => {
+      assert.throws(() => new Tafgeet('1e3'), InvalidAmountError);
+    });
+    it('is thrown for non-string currency', () => {
+      assert.throws(() => new Tafgeet(1, 42 as never), InvalidAmountError);
+    });
+    it('still passes instanceof TypeError (backward compat)', () => {
+      try {
+        new Tafgeet(null as never);
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, TypeError);
+        assert.instanceOf(e, InvalidAmountError);
+      }
+    });
+    it('has code === "INVALID_AMOUNT"', () => {
+      try {
+        new Tafgeet('abc');
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, InvalidAmountError);
+        assert.equal((e as InvalidAmountError).code, 'INVALID_AMOUNT');
+      }
+    });
+    it('has name === "InvalidAmountError"', () => {
+      const err = new InvalidAmountError('test');
+      assert.equal(err.name, 'InvalidAmountError');
+    });
+  });
+
+  describe('AmountOutOfRangeError', () => {
+    it('is thrown for NaN', () => {
+      assert.throws(() => new Tafgeet(NaN), AmountOutOfRangeError);
+    });
+    it('is thrown for Infinity', () => {
+      assert.throws(() => new Tafgeet(Infinity), AmountOutOfRangeError);
+    });
+    it('is thrown for negative number', () => {
+      assert.throws(() => new Tafgeet(-5), AmountOutOfRangeError);
+    });
+    it('is thrown for negative string', () => {
+      assert.throws(() => new Tafgeet('-5'), AmountOutOfRangeError);
+    });
+    it('is thrown for zero', () => {
+      assert.throws(() => new Tafgeet(0), AmountOutOfRangeError);
+    });
+    it('is thrown for 16+ digit integer', () => {
+      assert.throws(() => new Tafgeet('1000000000000000'), AmountOutOfRangeError);
+    });
+    it('still passes instanceof RangeError (backward compat)', () => {
+      try {
+        new Tafgeet(NaN);
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, RangeError);
+        assert.instanceOf(e, AmountOutOfRangeError);
+      }
+    });
+    it('has code === "AMOUNT_OUT_OF_RANGE"', () => {
+      try {
+        new Tafgeet(-5);
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, AmountOutOfRangeError);
+        assert.equal((e as AmountOutOfRangeError).code, 'AMOUNT_OUT_OF_RANGE');
+      }
+    });
+  });
+
+  describe('UnsupportedCurrencyError', () => {
+    it('is thrown for unknown currency', () => {
+      assert.throws(() => new Tafgeet(1, 'BTC'), UnsupportedCurrencyError);
+    });
+    it('still passes instanceof Error (backward compat)', () => {
+      try {
+        new Tafgeet(1, 'BTC');
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, Error);
+        assert.instanceOf(e, UnsupportedCurrencyError);
+      }
+    });
+    it('has code === "UNSUPPORTED_CURRENCY"', () => {
+      try {
+        new Tafgeet(1, 'BTC');
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.instanceOf(e, UnsupportedCurrencyError);
+        assert.equal((e as UnsupportedCurrencyError).code, 'UNSUPPORTED_CURRENCY');
+      }
+    });
+    it('message lists supported codes', () => {
+      try {
+        new Tafgeet(1, 'BTC');
+        assert.fail('should have thrown');
+      } catch (e) {
+        assert.match((e as Error).message, /SDG, SAR, QAR, AED, EGP, KWD, USD, AUD, TND, TRY/);
+      }
+    });
+  });
+
+  describe('isTafgeetError type guard', () => {
+    it('returns true for InvalidAmountError', () => {
+      assert.isTrue(isTafgeetError(new InvalidAmountError('msg')));
+    });
+    it('returns true for AmountOutOfRangeError', () => {
+      assert.isTrue(isTafgeetError(new AmountOutOfRangeError('msg')));
+    });
+    it('returns true for UnsupportedCurrencyError', () => {
+      assert.isTrue(isTafgeetError(new UnsupportedCurrencyError('msg')));
+    });
+    it('returns false for plain Error', () => {
+      assert.isFalse(isTafgeetError(new Error('msg')));
+    });
+    it('returns false for plain TypeError', () => {
+      assert.isFalse(isTafgeetError(new TypeError('msg')));
+    });
+    it('returns false for non-error values', () => {
+      assert.isFalse(isTafgeetError(null));
+      assert.isFalse(isTafgeetError(undefined));
+      assert.isFalse(isTafgeetError('error'));
+      assert.isFalse(isTafgeetError(42));
+      assert.isFalse(isTafgeetError({}));
+    });
+    it('narrows the type — code is accessible after guard', () => {
+      // Compile-time check: after isTafgeetError, `e.code` is typed.
+      const e: unknown = new InvalidAmountError('msg');
+      if (isTafgeetError(e)) {
+        const code: TafgeetErrorCode = e.code;
+        assert.equal(code, 'INVALID_AMOUNT');
+      }
+    });
+  });
+
+  describe('Structured error handling pattern', () => {
+    // Document the recommended way to handle errors uniformly.
+    function describeError(input: unknown, currency: unknown): { code: TafgeetErrorCode; message: string } | null {
+      try {
+        new Tafgeet(input as never, currency as never);
+        return null;
+      } catch (e) {
+        if (isTafgeetError(e)) {
+          return { code: e.code, message: e.message };
+        }
+        throw e;
+      }
+    }
+
+    it('returns INVALID_AMOUNT for non-numeric string', () => {
+      const result = describeError('abc', 'EGP');
+      assert.deepNestedInclude(result, { code: 'INVALID_AMOUNT' });
+    });
+    it('returns AMOUNT_OUT_OF_RANGE for negative', () => {
+      const result = describeError(-5, 'EGP');
+      assert.deepNestedInclude(result, { code: 'AMOUNT_OUT_OF_RANGE' });
+    });
+    it('returns UNSUPPORTED_CURRENCY for bad currency', () => {
+      const result = describeError(1, 'BTC');
+      assert.deepNestedInclude(result, { code: 'UNSUPPORTED_CURRENCY' });
+    });
+    it('returns null for valid input', () => {
+      assert.isNull(describeError('1', 'EGP'));
+    });
+  });
+});


### PR DESCRIPTION
PR 5 of the v1.2.0 series. New error API for structured catching, fully backward-compatible.

## New exports

```ts
import {
  InvalidAmountError,
  AmountOutOfRangeError,
  UnsupportedCurrencyError,
  isTafgeetError,
  type TafgeetErrorCode,
} from 'tafgeet-arabic';
```

| Class | Extends | `code` field | Thrown when |
|---|---|---|---|
| `InvalidAmountError` | `TypeError` | `'INVALID_AMOUNT'` | null, undefined, wrong type, non-numeric string, empty string, scientific notation, non-string currency |
| `AmountOutOfRangeError` | `RangeError` | `'AMOUNT_OUT_OF_RANGE'` | NaN, ±Infinity, negative, zero (int < 1), 16+ digit integer |
| `UnsupportedCurrencyError` | `Error` | `'UNSUPPORTED_CURRENCY'` | currency string not in `SUPPORTED_CURRENCIES` |

```ts
function isTafgeetError(e: unknown): e is InvalidAmountError | AmountOutOfRangeError | UnsupportedCurrencyError
```

## Why no shared `TafgeetError` base class?

JavaScript has no multiple inheritance. A single base couldn't both `extends Error` AND preserve `instanceof TypeError` / `instanceof RangeError` on subclasses. The `code` field + `isTafgeetError` guard provide the same "catch any tafgeet error" capability without forcing a choice between back-compat and structured catching.

## Recommended usage

```ts
try {
  new Tafgeet(input, currency).parse();
} catch (e) {
  if (isTafgeetError(e)) {
    switch (e.code) {
      case 'INVALID_AMOUNT':       reportToUser('Bad number');   break;
      case 'AMOUNT_OUT_OF_RANGE':  reportToUser('Out of range'); break;
      case 'UNSUPPORTED_CURRENCY': reportToUser('Bad currency'); break;
    }
  } else {
    throw e;
  }
}
```

## Backward compatibility

| | Status |
|---|---|
| All 406 prior tests | ✅ Pass byte-identical |
| All 262 snapshot outputs | ✅ Unchanged |
| `instanceof TypeError` patterns | ✅ Still match (subclass preserves it) |
| `instanceof RangeError` patterns | ✅ Still match |
| Error messages | ✅ Unchanged word-for-word |
| CJS + ESM smoke tests | ✅ Both pass |

Also tidied up the now-unreachable `throw new Error('Number out of range!')` in `parse()` — replaced with `AmountOutOfRangeError` for consistency. Still unreachable from the public API.

## Tests added

32 new tests covering each class, `instanceof` backward-compat checks, the type guard, and the recommended structured-handling pattern.

**Total: 438 tests pass (was 406).**