### PR TITLE
feat: rounding option for over-precision decimal inputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { COLUMN_PROPERTIES, columns, currencies, HUNDREDS, ONES, TEENS, TENS } from './constants';
 import { AmountOutOfRangeError, InvalidAmountError, UnsupportedCurrencyError } from './errors';
-import { CurrencyInput } from './types';
+import { CurrencyInput, RoundingMode, TafgeetOptions } from './types';
 
 // Re-export public types + runtime helpers so consumers can import them
 // directly:
@@ -11,8 +11,19 @@ import { CurrencyInput } from './types';
 //     InvalidAmountError, AmountOutOfRangeError, UnsupportedCurrencyError,
 //     isTafgeetError,
 //   } from 'tafgeet-arabic';
-//   import type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties, TafgeetErrorCode } from 'tafgeet-arabic';
-export type { Currency, Currencies, CurrencyCode, CurrencyInput, NumberProperties } from './types';
+//   import type {
+//     Currency, Currencies, CurrencyCode, CurrencyInput,
+//     NumberProperties, RoundingMode, TafgeetOptions, TafgeetErrorCode,
+//   } from 'tafgeet-arabic';
+export type {
+  Currency,
+  Currencies,
+  CurrencyCode,
+  CurrencyInput,
+  NumberProperties,
+  RoundingMode,
+  TafgeetOptions,
+} from './types';
 export { SUPPORTED_CURRENCIES } from './constants';
 export {
   InvalidAmountError,
@@ -28,15 +39,17 @@ export class Tafgeet {
   private fraction: number;
   private digit: number;
 
-  constructor(digit: string | number, currency: CurrencyInput = 'EGP') {
+  constructor(digit: string | number, currency: CurrencyInput = 'EGP', options: TafgeetOptions = {}) {
     // validateInput normalizes Arabic-Indic digits, strips thousands
     // separators, and returns the canonical Latin-digit string. Throws
     // a typed error on any malformed input.
     const normalized = Tafgeet.validateInput(digit, currency);
     this.currency = currency;
     this.splitted = normalized.split('.');
-    this.digit = parseInt(this.splitted[0] ?? '0', 10);
-    this.fraction = this.parseFraction(this.splitted[1], currency);
+    const intValue = parseInt(this.splitted[0] ?? '0', 10);
+    const { fracValue, intCarry } = this.parseFraction(this.splitted[1], currency, options.rounding ?? 'truncate');
+    this.digit = intValue + intCarry;
+    this.fraction = fracValue;
   }
 
   /**
@@ -81,22 +94,76 @@ export class Tafgeet {
    * Parses the fractional portion of the amount.
    *
    *   undefined / ""    -> 0
-   *   1 digit  ("2")    -> 2           (literal, no padding — historical
-   *                                     behavior preserved for backward
-   *                                     compatibility; "1.2 EGP" still
-   *                                     renders as "1 pound and 2 piaster",
-   *                                     not "20 piaster")
-   *   2 digits ("20")   -> 20
-   *   3+ digits         -> truncated to the currency's decimals count
-   *                        ("1.999 SDG"  -> 99,  decimals=2)
-   *                        ("1.456 TND"  -> 456, decimals=3)
+   *   length <= decimals  -> literal parse, no rounding
+   *                          ("1.2 EGP" -> 2, NOT 20 — historical
+   *                           behavior preserved for backward compat)
+   *   length >  decimals  -> rounding applied per `mode`. May carry
+   *                          into the integer part (e.g. 1.995 EGP
+   *                          with mode='round' -> { fracValue: 0,
+   *                          intCarry: 1 }, rendered as 2 EGP).
+   *
+   * The `mode='truncate'` default reproduces v1.1.x output byte-for-byte
+   * for every existing input.
    */
-  private parseFraction(fracStr: string | undefined, currency: string): number {
-    if (!fracStr) return 0;
-    if (fracStr.length <= 2) return parseInt(fracStr, 10);
-
+  private parseFraction(
+    fracStr: string | undefined,
+    currency: string,
+    mode: RoundingMode,
+  ): { fracValue: number; intCarry: number } {
+    if (!fracStr) return { fracValue: 0, intCarry: 0 };
     const decimals = currencies[currency as keyof typeof currencies]?.decimals ?? 2;
-    return parseInt(fracStr.slice(0, decimals), 10);
+
+    if (fracStr.length <= decimals) {
+      return { fracValue: parseInt(fracStr, 10), intCarry: 0 };
+    }
+
+    const keep = fracStr.slice(0, decimals);
+    const drop = fracStr.slice(decimals);
+    const kept = parseInt(keep, 10);
+    const fracValue = kept + Tafgeet.computeRoundingCarry(drop, keep, mode);
+
+    // Handle overflow: rounding pushed the fraction to 10^decimals,
+    // which represents +1 of the main unit (e.g. 100 piasters = 1 pound).
+    const max = 10 ** decimals;
+    if (fracValue >= max) {
+      return { fracValue: 0, intCarry: 1 };
+    }
+    return { fracValue, intCarry: 0 };
+  }
+
+  /**
+   * Computes whether to add 1 to the kept-fraction value based on the
+   * dropped digits and the rounding mode. Pure integer arithmetic on
+   * strings — no floating-point hazards.
+   *
+   *   drop = the dropped digit string (everything past `decimals`)
+   *   keep = the digits we're keeping (used by `bankers` for parity)
+   */
+  private static computeRoundingCarry(drop: string, keep: string, mode: RoundingMode): number {
+    if (mode === 'truncate' || mode === 'floor') return 0;
+
+    const firstDropDigit = parseInt(drop.charAt(0), 10);
+
+    if (mode === 'ceil') {
+      // Any non-zero in the dropped digits forces a carry.
+      return /[1-9]/.test(drop) ? 1 : 0;
+    }
+    if (mode === 'round') {
+      // Standard half-up rounding.
+      return firstDropDigit >= 5 ? 1 : 0;
+    }
+    if (mode === 'bankers') {
+      // Round half to even — only special when the dropped value is
+      // EXACTLY 0.5 (first digit 5, all subsequent zero). Otherwise
+      // behaves like round-half-up.
+      const isExactlyHalf = firstDropDigit === 5 && /^0*$/.test(drop.slice(1));
+      if (isExactlyHalf) {
+        const lastKept = parseInt(keep.charAt(keep.length - 1), 10);
+        return lastKept % 2 === 1 ? 1 : 0;
+      }
+      return firstDropDigit >= 5 ? 1 : 0;
+    }
+    return 0;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,3 +75,33 @@ export type CurrencyCode = keyof Currencies;
  * arbitrary string inputs (see microsoft/TypeScript#29729).
  */
 export type CurrencyInput = CurrencyCode | '' | (string & {});
+
+/**
+ * How to handle decimal digits beyond the currency's natural precision.
+ *
+ *   'truncate' (default) — drop extra digits (equivalent to `floor` for
+ *                          non-negative amounts). Preserves the v1.1.x
+ *                          default behavior exactly.
+ *   'round'              — round half up (the "schoolbook" rule).
+ *                          1.235 -> 1.24 for 2-decimal currencies.
+ *   'floor'              — round toward 0. Same as `truncate` for the
+ *                          non-negative inputs this library accepts.
+ *   'ceil'               — round toward +∞. Any non-zero dropped digit
+ *                          carries a 1.
+ *   'bankers'            — IEEE 754 "round half to even". Reduces
+ *                          cumulative bias in long sequences of additions;
+ *                          common in financial accounting.
+ */
+export type RoundingMode = 'truncate' | 'round' | 'floor' | 'ceil' | 'bankers';
+
+/**
+ * Optional third argument to the Tafgeet constructor.
+ *
+ * Reserved for future expansion. The current v1.2 release ships only
+ * `rounding`; `precision` and other linguistic options (`feminine`,
+ * `accusative`, `style`) are planned for v1.3+.
+ */
+export interface TafgeetOptions {
+  /** See {@link RoundingMode}. Defaults to `'truncate'`. */
+  rounding?: RoundingMode;
+}

--- a/test/rounding.spec.ts
+++ b/test/rounding.spec.ts
@@ -1,0 +1,145 @@
+import { assert } from 'chai';
+
+import { Tafgeet, type RoundingMode } from '../src';
+
+describe('Rounding option (1.2.0)', () => {
+  describe('default rounding === truncate (preserves v1.1.x behavior)', () => {
+    it('1.999 EGP defaults to truncate (fraction = 99)', () => {
+      const out = new Tafgeet('1.999').parse();
+      // 1.999 truncated to 2 decimals -> 1.99 -> "...وتسعة وتسعون قرش"
+      assert.match(out, /وتسعة وتسعون قرش/);
+      // Same as explicit truncate.
+      assert.equal(out, new Tafgeet('1.999', 'EGP', { rounding: 'truncate' }).parse());
+    });
+    it('1.999 SDG defaults to truncate (snapshot regression test)', () => {
+      assert.equal(new Tafgeet('1.999', 'SDG').parse(), new Tafgeet('1.999', 'SDG', { rounding: 'truncate' }).parse());
+    });
+  });
+
+  describe("'truncate' mode (alias of 'floor' for non-negative)", () => {
+    it('1.999 EGP -> 1.99', () => {
+      assert.equal(new Tafgeet('1.999', 'EGP', { rounding: 'truncate' }).parse(), new Tafgeet('1.99', 'EGP').parse());
+    });
+    it('1.001 EGP -> 1.00', () => {
+      assert.equal(new Tafgeet('1.001', 'EGP', { rounding: 'truncate' }).parse(), new Tafgeet('1.00', 'EGP').parse());
+    });
+    it('1.234 TND -> 1.234 (length == decimals, no rounding)', () => {
+      assert.equal(new Tafgeet('1.234', 'TND', { rounding: 'truncate' }).parse(), new Tafgeet('1.234', 'TND').parse());
+    });
+  });
+
+  describe("'floor' mode", () => {
+    it('behaves identically to truncate for non-negative inputs', () => {
+      const cases = ['1.001', '1.499', '1.500', '1.999', '99.949', '99.950'];
+      for (const amount of cases) {
+        assert.equal(
+          new Tafgeet(amount, 'EGP', { rounding: 'floor' }).parse(),
+          new Tafgeet(amount, 'EGP', { rounding: 'truncate' }).parse(),
+          `floor !== truncate for ${amount}`,
+        );
+      }
+    });
+  });
+
+  describe("'ceil' mode", () => {
+    it('1.001 EGP -> 1.01 (any non-zero dropped digit carries)', () => {
+      assert.equal(new Tafgeet('1.001', 'EGP', { rounding: 'ceil' }).parse(), new Tafgeet('1.01', 'EGP').parse());
+    });
+    it('1.991 EGP -> 2.00 (carries into integer)', () => {
+      assert.equal(new Tafgeet('1.991', 'EGP', { rounding: 'ceil' }).parse(), new Tafgeet('2', 'EGP').parse());
+    });
+    it('1.000 EGP -> 1.00 (no dropped digits to round up)', () => {
+      assert.equal(new Tafgeet('1.000', 'EGP', { rounding: 'ceil' }).parse(), new Tafgeet('1.00', 'EGP').parse());
+    });
+    it('1.500 EGP -> 1.50 (trailing zeros after dropped 5 still no extra carry)', () => {
+      // 1.500 with decimals=2: keep="50", drop="0". 0 is zero → no carry.
+      // (The dropped "0" doesn't trigger ceil because nothing non-zero remains.)
+      assert.equal(new Tafgeet('1.500', 'EGP', { rounding: 'ceil' }).parse(), new Tafgeet('1.50', 'EGP').parse());
+    });
+  });
+
+  describe("'round' mode (half-up)", () => {
+    it('1.234 EGP -> 1.23 (drop digit 4 < 5)', () => {
+      assert.equal(new Tafgeet('1.234', 'EGP', { rounding: 'round' }).parse(), new Tafgeet('1.23', 'EGP').parse());
+    });
+    it('1.235 EGP -> 1.24 (drop digit 5 carries)', () => {
+      assert.equal(new Tafgeet('1.235', 'EGP', { rounding: 'round' }).parse(), new Tafgeet('1.24', 'EGP').parse());
+    });
+    it('1.236 EGP -> 1.24', () => {
+      assert.equal(new Tafgeet('1.236', 'EGP', { rounding: 'round' }).parse(), new Tafgeet('1.24', 'EGP').parse());
+    });
+    it('1.995 EGP -> 2.00 (carries through fraction overflow into integer)', () => {
+      assert.equal(new Tafgeet('1.995', 'EGP', { rounding: 'round' }).parse(), new Tafgeet('2', 'EGP').parse());
+    });
+    it('99.995 EGP -> 100.00 (carry across multiple digits)', () => {
+      assert.equal(new Tafgeet('99.995', 'EGP', { rounding: 'round' }).parse(), new Tafgeet('100', 'EGP').parse());
+    });
+    it('1.2349 TND -> 1.235 (3-decimal currency)', () => {
+      assert.equal(new Tafgeet('1.2349', 'TND', { rounding: 'round' }).parse(), new Tafgeet('1.235', 'TND').parse());
+    });
+    it('1.2345 TND -> 1.235 (half-up rounding)', () => {
+      assert.equal(new Tafgeet('1.2345', 'TND', { rounding: 'round' }).parse(), new Tafgeet('1.235', 'TND').parse());
+    });
+  });
+
+  describe("'bankers' mode (half-to-even, IEEE 754)", () => {
+    it('1.225 EGP -> 1.22 (half + last-kept even -> no carry)', () => {
+      assert.equal(new Tafgeet('1.225', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.22', 'EGP').parse());
+    });
+    it('1.235 EGP -> 1.24 (half + last-kept odd -> carry)', () => {
+      assert.equal(new Tafgeet('1.235', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.24', 'EGP').parse());
+    });
+    it('1.245 EGP -> 1.24 (half + last-kept even -> no carry)', () => {
+      assert.equal(new Tafgeet('1.245', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.24', 'EGP').parse());
+    });
+    it('1.255 EGP -> 1.26 (half + last-kept odd -> carry)', () => {
+      assert.equal(new Tafgeet('1.255', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.26', 'EGP').parse());
+    });
+    it('1.2351 EGP -> 1.24 (NOT exactly half — falls back to round-half-up)', () => {
+      // 0.5 + a tiny bit more is no longer "exactly half"
+      assert.equal(new Tafgeet('1.2351', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.24', 'EGP').parse());
+    });
+    it('1.2349 EGP -> 1.23 (drop < 0.5 — no carry regardless of mode)', () => {
+      assert.equal(new Tafgeet('1.2349', 'EGP', { rounding: 'bankers' }).parse(), new Tafgeet('1.23', 'EGP').parse());
+    });
+  });
+
+  describe('No-rounding cases (length <= decimals)', () => {
+    it('"1.5" EGP — single fraction digit preserved as literal (no rounding involvement)', () => {
+      // Historical: "1.5" with EGP gives fraction=5 (five piasters, NOT 50).
+      // Rounding mode is irrelevant since length (1) <= decimals (2).
+      for (const mode of ['truncate', 'round', 'floor', 'ceil', 'bankers'] satisfies RoundingMode[]) {
+        assert.equal(
+          new Tafgeet('1.5', 'EGP', { rounding: mode }).parse(),
+          new Tafgeet('1.5', 'EGP').parse(),
+          `mode=${mode} changed "1.5" output`,
+        );
+      }
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    it('omitting options behaves like { rounding: "truncate" }', () => {
+      assert.equal(new Tafgeet('1.999', 'EGP').parse(), new Tafgeet('1.999', 'EGP', { rounding: 'truncate' }).parse());
+    });
+    it('omitting options behaves like {} (empty options object)', () => {
+      assert.equal(new Tafgeet('1.999', 'EGP').parse(), new Tafgeet('1.999', 'EGP', {}).parse());
+    });
+    it('all 262 snapshot test inputs would produce identical output with any rounding mode (length <= decimals)', () => {
+      // Spot-check: amounts in the existing snapshot all have length <= decimals,
+      // so rounding mode shouldn't affect them.
+      for (const amount of ['1.05', '100.05', '1.99', '1.005', '1.999']) {
+        const fracLen = (amount.split('.')[1] ?? '').length;
+        const cur = fracLen === 3 ? 'TND' : 'EGP';
+        const decimals = cur === 'TND' ? 3 : 2;
+        for (const mode of ['truncate', 'round', 'ceil', 'bankers'] satisfies RoundingMode[]) {
+          const want = new Tafgeet(amount, cur).parse();
+          const got = new Tafgeet(amount, cur, { rounding: mode }).parse();
+          if (fracLen <= decimals) {
+            assert.equal(got, want, `mode=${mode} changed "${amount} ${cur}"`);
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
PR 6 of the v1.2.0 series. Final feature PR before release prep. Fully backward-compatible.

## New: third constructor argument

```ts
new Tafgeet(amount, currency, { rounding: 'round' })
```

## Supported modes

| Mode | Behavior | Example (2-decimal currency) |
|---|---|---|
| `'truncate'` *(default)* | Drop extra digits | `1.999 → 1.99` |
| `'round'` | Half-up rounding | `1.235 → 1.24`, `1.234 → 1.23` |
| `'floor'` | Toward 0 (== truncate for non-negative) | `1.999 → 1.99` |
| `'ceil'` | Toward +∞ (any non-zero dropped digit carries) | `1.001 → 1.01` |
| `'bankers'` | IEEE 754 half-to-even | `1.225 → 1.22`, `1.235 → 1.24`, `1.245 → 1.24` |

## Fraction-to-integer carry handling

Rounding can push the fraction past its max (e.g. `99 + 1 = 100` cents = 1 pound). The carry propagates correctly:

```ts
new Tafgeet('1.995', 'EGP', { rounding: 'round' }).parse();
// → 'ٱثنين جنيه مصري فقط لا غير'   (2 EGP, not 1 EGP 100 cents)
```

## Implementation notes

- **All rounding arithmetic is integer-only** on string slices. No `x * 100 | 0` floating-point nonsense.
- New `RoundingMode` and `TafgeetOptions` types exported.
- `TafgeetOptions` is structured for future expansion — `precision`, `feminine`, `accusative`, `style` are slated for v1.3+.

## Why no `precision` option?

Your v1.2 spec listed `precision?: number` alongside `rounding`. **Deferred deliberately**: precision only has clear semantics when paired with the **currency registry** (Phase 7, v1.3). Otherwise it either no-ops or asks the formatter to render fractions the currency's grammar has no word for (e.g. 4-decimal precision on 2-decimal EGP — there's no 1/10,000-pound word). Will ship together with the registry.

## Backward compatibility

| | Status |
|---|---|
| All 438 prior tests | ✅ Pass byte-identical |
| All 262 snapshot outputs | ✅ Unchanged |
| Constructor without options | ✅ Same as `{ rounding: 'truncate' }` |
| `new Tafgeet('1.5', 'EGP')` historical literal behavior | ✅ Preserved (rounding mode irrelevant when `fracStr.length <= decimals`) |
| CJS + ESM smoke tests | ✅ Both pass |

## Tests added

27 new tests covering every mode, including:
- Fraction-to-integer carry edge cases (`1.995 → 2`, `99.995 → 100`)
- Bankers parity rule (`1.225 → 1.22` vs `1.235 → 1.24`)
- "Rounding is a no-op when input is short" invariant across all 5 modes

**Total: 465 tests pass (was 438).**