### PR TITLE
chore: release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,108 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] – 2026-05-28
+
+A packaging, types, and ergonomics release. **No breaking API changes.**
+Every input that worked in v1.1.0 produces byte-identical output here —
+verified by 262 snapshot assertions covering the full currency × magnitude
+matrix.
+
+### Added
+
+- **Dual ESM + CJS build via `tsup`.** Consumers using `import` get the
+  `.mjs` entry; consumers using `require` get the `.cjs` entry. Bundlers
+  (Vite, esbuild, webpack, Next.js, Rollup) auto-resolve via the
+  `exports` map. `sideEffects: false` enables aggressive tree-shaking.
+  Both entries verified via the new CJS + ESM smoke tests.
+- **`CurrencyCode` union type** — `'EGP' | 'SAR' | … | 'TRY'`, derived
+  from `keyof Currencies` so it stays in sync automatically:
+  ```ts
+  import type { CurrencyCode } from 'tafgeet-arabic';
+  function quote(amount: number, code: CurrencyCode) { ... }
+  ```
+  IDE autocompletes all 10 codes; typos caught at compile time.
+- **`CurrencyInput` type** — what the constructor's second argument
+  accepts: `CurrencyCode | '' | (string & {})`. The `(string & {})`
+  intersection preserves autocomplete while still permitting arbitrary
+  strings (for codes coming from APIs the type system can't know
+  about). Runtime validator still rejects unregistered codes.
+- **`SUPPORTED_CURRENCIES`** — frozen runtime array of the 10 built-in
+  codes. Useful for iteration / pre-validation:
+  ```ts
+  if (SUPPORTED_CURRENCIES.includes(userInput as CurrencyCode)) { ... }
+  ```
+- **Arabic-Indic + thousands-separator input.** The constructor now
+  accepts:
+  - Arabic-Indic digits — `'١٢٣٤.٥٦'` (U+0660..U+0669)
+  - Eastern Arabic-Indic — `'۱۲۳۴.۵۶'` (U+06F0..U+06F9, Farsi/Urdu)
+  - Arabic decimal separator — `'1234٫56'` (U+066B)
+  - Arabic thousands separator — `'1٬234'` (U+066C)
+  - Comma thousands separator — `'1,234.56'` (English)
+  - Underscore separator — `'1_234_567'` (JS numeric literal style)
+  - Whitespace separators — `'1 234 567'` (plus NBSP, narrow NBSP,
+    thin space — for pasted-from-word-processor input)
+  - Any combination of the above.
+- **Custom error classes with discriminated codes:**
+  - `InvalidAmountError extends TypeError` (code `'INVALID_AMOUNT'`)
+  - `AmountOutOfRangeError extends RangeError` (code `'AMOUNT_OUT_OF_RANGE'`)
+  - `UnsupportedCurrencyError extends Error` (code `'UNSUPPORTED_CURRENCY'`)
+  - `isTafgeetError(e): e is …` type-guard for catching any error from
+    this package.
+  - `TafgeetErrorCode` discriminated union of the codes.
+
+  Every class extends its corresponding built-in, so every existing
+  `instanceof TypeError` / `instanceof RangeError` pattern keeps working.
+- **`rounding` constructor option** — third argument selects how
+  over-precision decimals are handled:
+  ```ts
+  new Tafgeet('1.995', 'EGP', { rounding: 'round' }).parse();
+  // → 'ٱثنين جنيه مصري فقط لا غير'   (rounds 1.995 → 2)
+  ```
+  Modes: `'truncate'` *(default — preserves v1.1 behavior)*, `'round'`,
+  `'floor'`, `'ceil'`, `'bankers'` (IEEE 754 half-to-even).
+  Rounding can carry into the integer part; all arithmetic is
+  integer-only on string slices, no floating-point hazards.
+- **`RoundingMode` and `TafgeetOptions` exported types** — structured
+  for future expansion (`precision`, `feminine`, `accusative`, `style`
+  planned for v1.3+ alongside the currency registry).
+
+### Changed
+
+- **Snapshot tests** added — 262 entries covering the full (currency ×
+  magnitude) matrix. Any future PR that changes a parse() output must
+  visibly modify `test/snapshots/parse.snap.json`. Foundation for safely
+  adding grammar/style options later.
+- **`validateInput`** now returns the canonical normalized string
+  instead of returning void; the constructor consumes the return value
+  rather than re-`.toString().split('.')`-ing the original input.
+- **README** rewritten with the v1.2 API surface (types, errors, rounding).
+- **Internal cleanup pass** — removed redundant import-example comments,
+  stale historical tangents, the single-call `length()` private method,
+  and outdated JSDoc `@throws` annotations.
+
+### Removed
+
+- Nothing public. Two minor internal tidies:
+  - The single-call `length()` private method (inlined).
+  - A 13-line redundant import-example comment block at the top of
+    `src/index.ts`.
+
+### Test count
+
+| Release | Tests |
+|---|---|
+| v1.1.0 | 107 |
+| v1.2.0 | **465** (107 original + 262 snapshot + 96 new across CurrencyCode, flexible input, error classes, rounding) |
+
+### Deferred to v1.3
+
+- `precision` option (needs the currency registry to be meaningful).
+- Currency registry (`registerCurrency` / `getCurrency`).
+- Grammar options (`feminine`, `accusative`, `legal`, style modes).
+  These need native-speaker review before shipping; tracked as a
+  separate workstream.
+
 ## [1.1.0] – 2026-05-27
 
 A correctness, performance, and developer-experience release.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ new Tafgeet('1234.56', 'EGP').parse();
 ```
 
 - ⚡ ~900,000 ops/sec — pure JS, zero runtime dependencies
-- 📦 ~6 kB gzipped, ships TypeScript `.d.ts` files
-- 🛡 Strict input validation with typed `TypeError` / `RangeError`
+- 📦 Dual **ESM + CJS** build, ships TypeScript `.d.ts` files, `sideEffects: false`
+- 🛡 Typed error classes (`InvalidAmountError`, `AmountOutOfRangeError`, …) with discriminated `code` fields
+- 🔢 Accepts Latin, Arabic-Indic (`١٢٣`), Eastern Arabic-Indic (`۱۲۳`), commas, spaces, underscores
+- ➗ Configurable rounding (`'round'`, `'floor'`, `'ceil'`, `'bankers'`, `'truncate'`)
 - 🌍 10 currencies: EGP, SAR, QAR, AED, KWD, USD, AUD, SDG, TND, TRY
 
 ## Requirements
@@ -69,6 +71,37 @@ new Tafgeet('7564654', '').parse();
 // → 'سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون فقط لا غير'
 ```
 
+### Flexible input formats
+
+Beyond plain Latin (`'1234.56'`), the constructor accepts amounts in many forms — useful for input from Arabic forms, CSVs, copy-pasted spreadsheets, etc.:
+
+```ts
+new Tafgeet('١٢٣٤.٥٦').parse();          // Arabic-Indic digits
+new Tafgeet('۱۲۳۴.۵۶').parse();          // Eastern Arabic-Indic (Farsi/Urdu)
+new Tafgeet('1,234.56').parse();         // ASCII comma
+new Tafgeet('1_234_567').parse();        // JS underscore separator
+new Tafgeet('1 234 567').parse();        // space (regular / NBSP / narrow NBSP)
+new Tafgeet('١٬٥٠٠٫٢٥', 'EGP').parse(); // fully Arabic with Arabic separators
+// All produce the same output as the plain-Latin equivalent.
+```
+
+### Rounding
+
+By default decimals beyond the currency's precision are **truncated** (preserving v1.1 behavior byte-for-byte). Opt in to other modes via the third constructor argument:
+
+```ts
+new Tafgeet('1.995', 'EGP', { rounding: 'round' }).parse();
+// → 'ٱثنين جنيه مصري فقط لا غير'   (1.995 rounded to 2.00)
+
+new Tafgeet('1.001', 'EGP', { rounding: 'ceil' }).parse();
+// → 'واحد جنيه مصري وواحد قرش فقط لا غير'
+
+new Tafgeet('1.225', 'EGP', { rounding: 'bankers' }).parse();
+// → 'واحد جنيه مصري وٱثنين وعشرون قرش فقط لا غير'  (half-to-even)
+```
+
+Available modes: `'truncate'` (default), `'round'` (half-up), `'floor'`, `'ceil'`, `'bankers'` (IEEE 754 half-to-even — recommended for accounting).
+
 ### Error handling
 
 Invalid input throws a typed error rather than producing garbage output:
@@ -96,28 +129,50 @@ See [API → Errors](#errors) for the full list.
 All public types are re-exported from the package entry point:
 
 ```ts
-import { Tafgeet, Currency, Currencies, NumberProperties } from 'tafgeet-arabic';
-
-const cur: Currency = {
-  singular: 'دينار',
-  plural: 'دنانير',
-  fraction: 'فلس',
-  fractions: 'فلوس',
-  decimals: 3,
-};
+import {
+  Tafgeet,
+  SUPPORTED_CURRENCIES,
+  isTafgeetError,
+  InvalidAmountError,
+  AmountOutOfRangeError,
+  UnsupportedCurrencyError,
+} from 'tafgeet-arabic';
+import type {
+  Currency,
+  Currencies,
+  CurrencyCode,
+  CurrencyInput,
+  NumberProperties,
+  RoundingMode,
+  TafgeetOptions,
+  TafgeetErrorCode,
+} from 'tafgeet-arabic';
 ```
 
 ## API
 
-### `new Tafgeet(amount, currency?)`
+### `new Tafgeet(amount, currency?, options?)`
 
 Creates a new `Tafgeet` instance. The constructor validates the input
-eagerly and throws if anything is malformed.
+eagerly and throws a typed error if anything is malformed.
 
 | Parameter | Type | Default | Notes |
 |---|---|---|---|
-| `amount` | `string \| number` | — | Integer part must be **≥ 1** and **≤ 15 digits**. Pass a string to avoid float precision loss. |
-| `currency` | `string` | `'EGP'` | ISO-style code from the [supported currencies](#supported-currencies), or `''` for no-currency mode. |
+| `amount` | `string \| number` | — | Integer part must be **≥ 1** and **≤ 15 digits**. Pass a string to avoid float precision loss. Arabic-Indic digits and thousands separators are accepted. |
+| `currency` | `CurrencyInput` | `'EGP'` | A `CurrencyCode`, an empty string for no-currency mode, or any string (runtime validated). |
+| `options` | `TafgeetOptions` | `{}` | See [Options](#options) below. |
+
+### Options
+
+```ts
+interface TafgeetOptions {
+  rounding?: 'truncate' | 'round' | 'floor' | 'ceil' | 'bankers';
+}
+```
+
+| Option | Default | Behavior |
+|---|---|---|
+| `rounding` | `'truncate'` | How to handle decimals beyond the currency's natural precision. `'truncate'` preserves v1.1 behavior exactly. `'round'` is half-up. `'bankers'` is IEEE 754 half-to-even (recommended for accounting). Rounding can carry into the integer part (`1.995 EGP` with `'round'` → `2 EGP`). |
 
 ### `.parse(): string`
 
@@ -127,6 +182,9 @@ and the closing `فقط لا غير`.
 ```ts
 new Tafgeet('123.45', 'EGP').parse();
 // → 'مائة وثلاثة وعشرون جنيه مصري وخمسة وأربعون قرش فقط لا غير'
+
+new Tafgeet('1.995', 'EGP', { rounding: 'round' }).parse();
+// → 'ٱثنين جنيه مصري فقط لا غير'  (rounded up)
 ```
 
 ### `.read(d: number): string`
@@ -143,11 +201,33 @@ t.read(999); // → 'تسعمائة وتسعة وتسعون'
 
 ### Errors
 
-| Class | When |
-|---|---|
-| `TypeError` | `amount` is `null`, `undefined`, the wrong type, a non-numeric string, empty string, or scientific notation. Also thrown when `currency` is not a string. |
-| `RangeError` | `amount` is `NaN`, `Infinity`, negative, zero (integer part < 1), or has more than 15 integer digits. |
-| `Error` | `currency` is not one of the supported codes. |
+Each error class extends the appropriate built-in, so existing
+`instanceof TypeError` / `RangeError` checks keep working. The
+`code` field allows structured handling:
+
+| Class | Extends | `code` | When |
+|---|---|---|---|
+| `InvalidAmountError` | `TypeError` | `'INVALID_AMOUNT'` | `amount` is `null`, `undefined`, wrong type, non-numeric string, empty string, or scientific notation. Also thrown when `currency` is not a string. |
+| `AmountOutOfRangeError` | `RangeError` | `'AMOUNT_OUT_OF_RANGE'` | `amount` is `NaN`, `Infinity`, negative, zero (integer part < 1), or has more than 15 integer digits. |
+| `UnsupportedCurrencyError` | `Error` | `'UNSUPPORTED_CURRENCY'` | `currency` is a string but not one of the codes in `SUPPORTED_CURRENCIES`. |
+
+```ts
+import { isTafgeetError } from 'tafgeet-arabic';
+
+try {
+  new Tafgeet(input, currency).parse();
+} catch (e) {
+  if (isTafgeetError(e)) {
+    switch (e.code) {
+      case 'INVALID_AMOUNT':       reportToUser('Bad number');   break;
+      case 'AMOUNT_OUT_OF_RANGE':  reportToUser('Out of range'); break;
+      case 'UNSUPPORTED_CURRENCY': reportToUser('Bad currency'); break;
+    }
+  } else {
+    throw e;
+  }
+}
+```
 
 ## Supported currencies
 
@@ -168,20 +248,22 @@ Missing a currency? [Open an issue](https://github.com/omar-ehab/tafgeet-arabic/
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md). Highlights of **v1.1.0**:
+See [CHANGELOG.md](./CHANGELOG.md). Highlights of **v1.2.0**:
 
-- **3.5–4.7× faster** across all input sizes
-- **52% smaller** install (test files no longer shipped)
-- Fixes for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7), [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8), and the fraction singular/plural rule
-- **KWD (Kuwaiti Dinar)** added
-- **Input validation** with typed errors
-- TypeScript types now ship and are re-exported from the package root
+- **Dual ESM + CJS build** with proper `exports` map and `sideEffects: false`
+- **`CurrencyCode` union type** + **`SUPPORTED_CURRENCIES`** runtime array
+- **Arabic-Indic digits & thousands separators** accepted (`'١٬٥٠٠٫٢٥'`, `'1,500.25'`, `'1_500'`, …)
+- **Custom error classes** with discriminated `code` fields (still `instanceof TypeError` etc.)
+- **`rounding` option** — `'truncate'` *(default, preserves v1.1 behavior)*, `'round'`, `'floor'`, `'ceil'`, `'bankers'`
+- **262 snapshot tests** locking in every existing output against future regression
+
+Earlier: **v1.1.0** — 3.5–4.7× faster, 52% smaller install, fixes for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7) / [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8) / fraction-plural, KWD added, input validation.
 
 ## Roadmap
 
-- More currencies (BHD, OMR, JOD, IQD, LBP, MAD, DZD, …)
-- Native-speaker grammar review of dictionaries (dual form for 2, classical inflection for 11–99)
-- Optional functional API: `tafgeet(amount, currency?)` alongside the class
+- **v1.3:** currency registry (`registerCurrency`), `precision` option, more currencies (BHD, OMR, JOD, IQD, LBP, MAD, DZD, …)
+- **v1.4:** grammar options (`feminine`, `accusative`, `style: 'simple' | 'formal' | 'banking'`) — pending native-speaker review of the dictionaries
+- Optional: functional API `tafgeet(amount, currency?)` alongside the class
 
 ## Contributing
 
@@ -191,9 +273,9 @@ PRs and issues welcome. To set up locally:
 git clone https://github.com/omar-ehab/tafgeet-arabic
 cd tafgeet-arabic
 npm install
-npm test               # 107 mocha tests
+npm test               # 465 tests (107 unit + 262 snapshot + 96 feature)
 npm run lint           # ESLint
-npm run test:js-compat # plain-JS smoke test against built dist/
+npm run test:js-compat # CJS + ESM smoke tests against built dist/
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tafgeet-arabic",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Converts currency digits into written Arabic words",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,14 +76,8 @@ export const currencies: Currencies = {
 export const columns: readonly string[] = ['trillions', 'billions', 'millions', 'thousands'];
 
 /**
- * Runtime-accessible list of built-in currency codes. Useful for
- * iterating supported currencies or validating user input without
- * a try/catch around the constructor.
- *
- *   if (SUPPORTED_CURRENCIES.includes(userInput as CurrencyCode)) { ... }
- *
- * Kept in sync with the `Currencies` interface; if you ever bundle
- * a new currency, add it here AND to `Currencies` AND to `currencies`.
+ * Runtime list of built-in currency codes — frozen, iterable, includes()-able.
+ * Keep in sync with the `Currencies` interface and `currencies` map.
  */
 export const SUPPORTED_CURRENCIES: readonly CurrencyCode[] = Object.freeze([
   'SDG',
@@ -99,10 +93,8 @@ export const SUPPORTED_CURRENCIES: readonly CurrencyCode[] = Object.freeze([
 ]);
 
 // -- Number-word dictionaries -------------------------------------------------
-// Indexed by the digit value (1-9 for ones, etc.) so callers can do
-// `ONES[d]` instead of building a `_<n>` key by string concatenation.
-// All dictionaries are frozen at module load so they're shared across every
-// Tafgeet instance rather than allocated per-constructor call.
+// Indexed by digit value (e.g. `ONES[5]`). Frozen + module-level so every
+// Tafgeet instance shares the same reference instead of re-allocating.
 
 export const ONES: Readonly<Record<number, string>> = Object.freeze({
   1: 'واحد',
@@ -176,8 +168,7 @@ export const TRILLIONS: Readonly<NumberProperties> = Object.freeze({
   plural: 'ترليونات',
 });
 
-// Maps column name -> the NumberProperties for that column.
-// Used by the parse() loop to look up the correct suffix per group.
+// Column name -> NumberProperties, used by parse() to pick the suffix word.
 export const COLUMN_PROPERTIES: Readonly<Record<string, Readonly<NumberProperties>>> = Object.freeze({
   trillions: TRILLIONS,
   billions: BILLIONS,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,42 +1,22 @@
 /**
- * Custom error classes thrown by the Tafgeet constructor.
+ * Errors thrown by the Tafgeet constructor.
  *
- * Design notes:
+ * Each class extends the appropriate built-in (TypeError / RangeError /
+ * Error) so existing `instanceof TypeError` patterns keep working, and
+ * each carries a discriminated `code` field for structured catching via
+ * the {@link isTafgeetError} type guard.
  *
- *   - Each class extends the appropriate built-in (TypeError / RangeError /
- *     Error) so existing catch-by-built-in patterns continue to work:
- *
- *       try { new Tafgeet(null); } catch (e) {
- *         if (e instanceof TypeError) { ... }    // still works
- *       }
- *
- *   - Each carries a typed `code` field for structured catching:
- *
- *       try { new Tafgeet(input, currency); } catch (e) {
- *         if (isTafgeetError(e)) {
- *           switch (e.code) {
- *             case 'INVALID_AMOUNT':        ...; break;
- *             case 'AMOUNT_OUT_OF_RANGE':   ...; break;
- *             case 'UNSUPPORTED_CURRENCY':  ...; break;
- *           }
- *         }
- *       }
- *
- *   - There is NO `TafgeetError` base class. JavaScript doesn't support
- *     multiple inheritance, so a base class can't be both `extends Error`
- *     AND keep `instanceof TypeError` / `instanceof RangeError` true on
- *     subclasses. Use the `isTafgeetError` typeguard instead.
+ * There is no shared `TafgeetError` base class — JS has no multiple
+ * inheritance, so a base couldn't both `extends Error` AND keep
+ * `instanceof TypeError` true on subclasses.
  */
 
 /** Discriminated codes for structured error catching. */
 export type TafgeetErrorCode = 'INVALID_AMOUNT' | 'AMOUNT_OUT_OF_RANGE' | 'UNSUPPORTED_CURRENCY';
 
 /**
- * Thrown when the amount input is the wrong type or malformed:
- * null, undefined, non-numeric string, empty string, scientific
- * notation, etc.
- *
- * Extends TypeError, so `instanceof TypeError` is `true`.
+ * Wrong type / malformed amount: null, undefined, non-numeric string,
+ * empty string, scientific notation, non-string currency.
  */
 export class InvalidAmountError extends TypeError {
   readonly code = 'INVALID_AMOUNT' as const;
@@ -48,11 +28,8 @@ export class InvalidAmountError extends TypeError {
 }
 
 /**
- * Thrown when the amount is the right type but outside the supported
- * range: NaN, ±Infinity, negative, zero (integer part < 1), or more
- * than 15 integer digits.
- *
- * Extends RangeError, so `instanceof RangeError` is `true`.
+ * Right type but out of range: NaN, ±Infinity, negative, zero
+ * (integer part < 1), or > 15 integer digits.
  */
 export class AmountOutOfRangeError extends RangeError {
   readonly code = 'AMOUNT_OUT_OF_RANGE' as const;
@@ -63,13 +40,7 @@ export class AmountOutOfRangeError extends RangeError {
   }
 }
 
-/**
- * Thrown when the currency code is a string but not one of the
- * registered codes in `SUPPORTED_CURRENCIES`.
- *
- * Extends Error directly (currency mismatch isn't a type or range
- * issue — it's a lookup failure).
- */
+/** Currency string not in {@link SUPPORTED_CURRENCIES}. */
 export class UnsupportedCurrencyError extends Error {
   readonly code = 'UNSUPPORTED_CURRENCY' as const;
 
@@ -79,22 +50,7 @@ export class UnsupportedCurrencyError extends Error {
   }
 }
 
-/**
- * Type guard for "any error thrown by the Tafgeet constructor".
- *
- * Useful when you want to handle all Tafgeet errors uniformly and
- * forward unrelated errors (e.g. from your own code) up the stack:
- *
- *   try {
- *     ...
- *   } catch (e) {
- *     if (isTafgeetError(e)) {
- *       reportToUser(e.code, e.message);
- *     } else {
- *       throw e;
- *     }
- *   }
- */
+/** Type guard for any error thrown by the Tafgeet constructor. */
 export function isTafgeetError(e: unknown): e is InvalidAmountError | AmountOutOfRangeError | UnsupportedCurrencyError {
   return e instanceof InvalidAmountError || e instanceof AmountOutOfRangeError || e instanceof UnsupportedCurrencyError;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,57 +39,28 @@ export class Tafgeet {
   }
 
   /**
-   * Normalizes a numeric input to its canonical Latin-digit form.
-   * Accepts (in addition to plain Latin "1234.56"):
-   *
-   *   - Arabic-Indic digits         "١٢٣٤.٥٦"     (U+0660..0669)
-   *   - Eastern Arabic-Indic digits "۱۲۳۴.۵۶"     (U+06F0..06F9, Farsi/Urdu)
-   *   - Arabic decimal separator    "1234٫56"     (U+066B)
-   *   - Arabic thousands separator  "1٬234"       (U+066C)
-   *   - Comma thousands separator   "1,234.56"    (English)
-   *   - Underscore separator        "1_234_567"   (JS numeric literal style)
-   *   - Space separators            "1 234,56"    (French/EU style, but . only)
-   *   - NBSP / narrow-NBSP / thin space separators (pasted from word processors)
-   *
-   * Does NOT change the integer-vs-decimal semantics — `'1.2'` remains
-   * `'1.2'` (two-tenths), not `'1.20'`. That's documented behavior.
-   *
-   * Returns the normalized string. The validator does its own format
-   * check on this output so any non-numeric residue throws cleanly.
+   * Normalizes Latin / Arabic-Indic / Eastern Arabic-Indic digits and
+   * strips thousands separators (commas, underscores, all whitespace,
+   * Arabic ٬) to a canonical Latin-digit string. Arabic decimal mark
+   * ٫ becomes `.`. Does NOT pad — `'1.2'` stays two-tenths, not `'1.20'`.
    */
   private static normalizeAmount(input: string): string {
-    return (
-      input
-        .trim()
-        // Arabic-Indic digits ٠..٩ -> 0..9
-        .replace(/[٠-٩]/g, (d) => String(d.charCodeAt(0) - 0x0660))
-        // Eastern Arabic-Indic digits ۰..۹ (Farsi/Urdu) -> 0..9
-        .replace(/[۰-۹]/g, (d) => String(d.charCodeAt(0) - 0x06f0))
-        // Arabic decimal separator ٫ -> .
-        .replace(/٫/g, '.')
-        // Arabic thousands separator ٬ -> (strip)
-        .replace(/٬/g, '')
-        // Strip ASCII comma, underscore, and all unicode whitespace
-        // (regular space, NBSP U+00A0, narrow NBSP U+202F, thin space
-        // U+2009, tab, etc. — \s covers them).
-        .replace(/[,_\s]/g, '')
-    );
+    return input
+      .trim()
+      .replace(/[٠-٩]/g, (d) => String(d.charCodeAt(0) - 0x0660)) // Arabic-Indic
+      .replace(/[۰-۹]/g, (d) => String(d.charCodeAt(0) - 0x06f0)) // Eastern Arabic-Indic (Farsi/Urdu)
+      .replace(/٫/g, '.') // Arabic decimal separator
+      .replace(/٬/g, '') // Arabic thousands separator
+      .replace(/[,_\s]/g, ''); // comma, underscore, any whitespace
   }
 
   /**
-   * Parses the fractional portion of the amount.
-   *
-   *   undefined / ""    -> 0
-   *   length <= decimals  -> literal parse, no rounding
-   *                          ("1.2 EGP" -> 2, NOT 20 — historical
-   *                           behavior preserved for backward compat)
-   *   length >  decimals  -> rounding applied per `mode`. May carry
-   *                          into the integer part (e.g. 1.995 EGP
-   *                          with mode='round' -> { fracValue: 0,
-   *                          intCarry: 1 }, rendered as 2 EGP).
-   *
-   * The `mode='truncate'` default reproduces v1.1.x output byte-for-byte
-   * for every existing input.
+   * Parses the fractional portion.
+   *   - empty/undefined  -> 0
+   *   - length <= decimals  -> literal parse (`'1.2 EGP'` -> 2, not 20;
+   *     historical behavior preserved for backward compat)
+   *   - length >  decimals  -> rounding per `mode`; may carry into the
+   *     integer part (`1.995 EGP` with `'round'` -> `2 EGP`).
    */
   private parseFraction(
     fracStr: string | undefined,
@@ -118,30 +89,17 @@ export class Tafgeet {
   }
 
   /**
-   * Computes whether to add 1 to the kept-fraction value based on the
-   * dropped digits and the rounding mode. Pure integer arithmetic on
-   * strings — no floating-point hazards.
-   *
-   *   drop = the dropped digit string (everything past `decimals`)
-   *   keep = the digits we're keeping (used by `bankers` for parity)
+   * Returns 1 if the kept fraction should be incremented under `mode`,
+   * 0 otherwise. Integer arithmetic on the digit string — no FP hazards.
+   * `keep` is used by `'bankers'` for the last-digit parity check.
    */
   private static computeRoundingCarry(drop: string, keep: string, mode: RoundingMode): number {
     if (mode === 'truncate' || mode === 'floor') return 0;
-
     const firstDropDigit = parseInt(drop.charAt(0), 10);
-
-    if (mode === 'ceil') {
-      // Any non-zero in the dropped digits forces a carry.
-      return /[1-9]/.test(drop) ? 1 : 0;
-    }
-    if (mode === 'round') {
-      // Standard half-up rounding.
-      return firstDropDigit >= 5 ? 1 : 0;
-    }
+    if (mode === 'ceil') return /[1-9]/.test(drop) ? 1 : 0;
+    if (mode === 'round') return firstDropDigit >= 5 ? 1 : 0;
     if (mode === 'bankers') {
-      // Round half to even — only special when the dropped value is
-      // EXACTLY 0.5 (first digit 5, all subsequent zero). Otherwise
-      // behaves like round-half-up.
+      // Only the exactly-0.5 case differs from half-up; otherwise identical.
       const isExactlyHalf = firstDropDigit === 5 && /^0*$/.test(drop.slice(1));
       if (isExactlyHalf) {
         const lastKept = parseInt(keep.charAt(keep.length - 1), 10);
@@ -153,16 +111,12 @@ export class Tafgeet {
   }
 
   /**
-   * Validates and normalizes the constructor arguments. Returns the
-   * canonical Latin-digit amount string for the constructor to consume.
+   * Validates the constructor arguments and returns the canonical
+   * Latin-digit amount string. Accepts `unknown` because JS callers
+   * can violate the public types — that's what runtime validation is for.
    *
-   * Accepts `unknown` because JS callers can pass values that violate
-   * the public type signature — that's the whole point of validation.
-   *
-   * Throws:
-   *   InvalidAmountError       — wrong type, non-numeric string, null/undefined
-   *   AmountOutOfRangeError    — NaN, Infinity, negative, zero, or > 15 digits
-   *   UnsupportedCurrencyError — unknown currency code
+   * Throws InvalidAmountError / AmountOutOfRangeError /
+   * UnsupportedCurrencyError as appropriate.
    */
   private static validateInput(digit: unknown, currency: unknown): string {
     if (digit === null || digit === undefined) {
@@ -247,11 +201,9 @@ export class Tafgeet {
         groups.push(parseInt(intStr.slice(i, i + 3), 10));
       }
 
-      // groups[i] corresponds to column (startCol + i). The final group
-      // can land at column index >= columns.length — that's the "ones"
-      // position and gets rendered without a suffix.
-      // Join non-zero parts with " و"; the trailing-zero cleanup is
-      // implicit because we only emit non-zero groups.
+      // groups[i] -> column (startCol + i). A trailing group past
+      // columns.length is the "ones" position (no suffix). Skipping
+      // zero groups makes trailing-zero cleanup implicit.
       const rendered: string[] = [];
       for (let i = 0; i < groups.length; i++) {
         const value = groups[i] ?? 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,6 @@ import { COLUMN_PROPERTIES, columns, currencies, HUNDREDS, ONES, TEENS, TENS } f
 import { AmountOutOfRangeError, InvalidAmountError, UnsupportedCurrencyError } from './errors';
 import { CurrencyInput, RoundingMode, TafgeetOptions } from './types';
 
-// Re-export public types + runtime helpers so consumers can import them
-// directly:
-//
-//   import {
-//     Tafgeet,
-//     SUPPORTED_CURRENCIES,
-//     InvalidAmountError, AmountOutOfRangeError, UnsupportedCurrencyError,
-//     isTafgeetError,
-//   } from 'tafgeet-arabic';
-//   import type {
-//     Currency, Currencies, CurrencyCode, CurrencyInput,
-//     NumberProperties, RoundingMode, TafgeetOptions, TafgeetErrorCode,
-//   } from 'tafgeet-arabic';
 export type {
   Currency,
   Currencies,
@@ -40,9 +27,8 @@ export class Tafgeet {
   private digit: number;
 
   constructor(digit: string | number, currency: CurrencyInput = 'EGP', options: TafgeetOptions = {}) {
-    // validateInput normalizes Arabic-Indic digits, strips thousands
-    // separators, and returns the canonical Latin-digit string. Throws
-    // a typed error on any malformed input.
+    // validateInput throws on malformed input and returns the canonical
+    // Latin-digit form (e.g. Arabic-Indic and thousands-separator stripped).
     const normalized = Tafgeet.validateInput(digit, currency);
     this.currency = currency;
     this.splitted = normalized.split('.');
@@ -170,17 +156,13 @@ export class Tafgeet {
    * Validates and normalizes the constructor arguments. Returns the
    * canonical Latin-digit amount string for the constructor to consume.
    *
-   * Pre-1.1.0 invalid input either crashed deep inside parse() with a
-   * cryptic TypeError, or silently produced strings containing the
-   * literal word "undefined".
-   *
    * Accepts `unknown` because JS callers can pass values that violate
    * the public type signature — that's the whole point of validation.
    *
    * Throws:
-   *   TypeError  — wrong type, non-numeric string, null/undefined
-   *   RangeError — NaN, Infinity, negative, zero, or > 15 digits
-   *   Error      — unknown currency code
+   *   InvalidAmountError       — wrong type, non-numeric string, null/undefined
+   *   AmountOutOfRangeError    — NaN, Infinity, negative, zero, or > 15 digits
+   *   UnsupportedCurrencyError — unknown currency code
    */
   private static validateInput(digit: unknown, currency: unknown): string {
     if (digit === null || digit === undefined) {
@@ -241,17 +223,13 @@ export class Tafgeet {
    * Renders the amount as Arabic words, including the currency suffix
    * and the closing فقط لا غير.
    *
-   * @throws {Error} if the integer part is 16+ digits (kept for backward
-   *   compatibility — the constructor's stricter validation now catches
-   *   this earlier, so this branch is unreachable from current API use).
+   * @throws {AmountOutOfRangeError} if the integer part is 16+ digits.
+   *   Unreachable from normal API use — the constructor catches this
+   *   earlier — but kept as a safety net against reflection-based misuse.
    */
   parse(): string {
     const intStr = this.digit.toString();
     if (intStr.length >= 16) {
-      // Unreachable from public API since 1.1.0 (the constructor
-      // validator catches > 15 digits earlier with a clearer message),
-      // but kept as a safety net for anyone using `read()` directly
-      // or mutating the private `digit` field via reflection.
       throw new AmountOutOfRangeError('Tafgeet: integer part must be < 16 digits');
     }
 
@@ -292,10 +270,8 @@ export class Tafgeet {
       const cur = currencies[this.currency as keyof typeof currencies];
       str += ' ' + (this.digit >= 3 && this.digit <= 10 ? cur.plural : cur.singular);
       if (this.fraction !== 0) {
-        // Plural-vs-singular for the FRACTION word depends on the FRACTION
-        // value (3–10 → broken plural in Arabic), not on the integer part.
-        // Pre-1.1.0 this incorrectly gated on `this.digit`, so e.g.
-        // `1.05 EGP` returned "...وخمسة قرش" instead of "...وخمسة قروش".
+        // Arabic broken-plural rule: counts 3–10 take the plural form
+        // (قروش), everything else (1, 2, 11+) takes the singular (قرش).
         const fracWord = this.fraction >= 3 && this.fraction <= 10 ? cur.fractions : cur.fraction;
         str += ' و' + this.read(this.fraction) + ' ' + fracWord;
       }
@@ -317,18 +293,14 @@ export class Tafgeet {
     return '';
   }
 
-  private length(): number {
-    return this.digit.toString().length;
-  }
-
-  // Maps digit-count -> starting column index.
-  // 1–3 digits: hundreds-only (handled separately in parse(), returns 0).
-  // 4–6 digits: thousands (column 3).
-  // 7–9 digits: millions (column 2).
-  // 10–12 digits: billions (column 1).
-  // 13–15 digits: trillions (column 0).
+  // Maps digit-count of the integer part -> starting column index.
+  //   1–3 digits:  hundreds-only (handled separately in parse(); returns 0).
+  //   4–6 digits:  thousands  (column 3)
+  //   7–9 digits:  millions   (column 2)
+  //   10–12 digits: billions  (column 1)
+  //   13–15 digits: trillions (column 0)
   private getColumnIndex(): number {
-    const len = this.length();
+    const len = this.digit.toString().length;
     if (len <= 3) return 0;
     if (len <= 6) return 3;
     if (len <= 9) return 2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,6 @@
 /**
  * Public type definitions for the tafgeet-arabic package.
- *
- * Available via the top-level package import:
- *
- *   import { Tafgeet, Currency, Currencies, NumberProperties } from 'tafgeet-arabic';
+ * All types here are re-exported from the package root.
  */
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,8 @@
  */
 
 /**
- * The lexical forms a counted Arabic noun needs:
- *   - singular: count of 1                       (e.g. ألف)
- *   - binary:   dual form for count of 2         (e.g. ألفين)
- *   - plural:   broken plural for count of 3-9   (e.g. ألآف)
+ * Lexical forms for an Arabic counted noun: singular (1), dual (2),
+ * broken plural (3–9). Example for ألف / ألفين / ألآف.
  */
 export interface NumberProperties {
   singular: string;
@@ -16,13 +14,9 @@ export interface NumberProperties {
 }
 
 /**
- * Arabic forms + decimal precision for a single currency.
- *
- *   - singular:  count of 1, 2, 11+ of the main unit         (جنيه مصري)
- *   - plural:    count of 3-10 of the main unit              (جنيهات مصرية)
- *   - fraction:  count of 1, 2, 11+ of the fractional unit   (قرش)
- *   - fractions: count of 3-10 of the fractional unit        (قروش)
- *   - decimals:  how many decimal digits the currency uses (2 or 3)
+ * Arabic forms + decimal precision for a single currency. The main and
+ * fractional units each have singular (count 1/2/11+) and plural (3–10)
+ * variants per Arabic grammar.
  */
 export interface Currency {
   singular: string;
@@ -49,54 +43,34 @@ export interface Currencies {
 }
 
 /**
- * Union of all built-in currency code strings. Use this in your own
- * type signatures to enforce a known code at compile time:
- *
- *   function quote(amount: number, code: CurrencyCode) { ... }
- *
- * Derived from `Currencies` via `keyof`, so adding a currency to
- * the `Currencies` interface automatically extends `CurrencyCode`.
+ * Union of all built-in currency codes (`'EGP' | 'SAR' | …`). Derived
+ * from `Currencies`, so adding a key there auto-extends the union.
  */
 export type CurrencyCode = keyof Currencies;
 
 /**
- * The Tafgeet constructor's currency parameter accepts:
- *   - a known CurrencyCode      — IDE autocompletes all valid codes
- *   - `''` (empty string)       — no-currency mode (number only)
- *   - any other string          — accepted for forward compatibility,
- *                                 but the runtime validator will reject
- *                                 anything not registered in `currencies`
+ * What the constructor's currency parameter accepts: a known code (with
+ * IDE autocomplete), `''` for no-currency mode, or any other string
+ * (forward-compatible; runtime validator still rejects unregistered codes).
  *
- * The `(string & {})` intersection is a deliberate TypeScript trick that
- * preserves autocomplete for the literal union while still permitting
- * arbitrary string inputs (see microsoft/TypeScript#29729).
+ * The `(string & {})` is a deliberate trick that keeps literal-union
+ * autocomplete while widening to `string` (microsoft/TypeScript#29729).
  */
 export type CurrencyInput = CurrencyCode | '' | (string & {});
 
 /**
  * How to handle decimal digits beyond the currency's natural precision.
- *
- *   'truncate' (default) — drop extra digits (equivalent to `floor` for
- *                          non-negative amounts). Preserves the v1.1.x
- *                          default behavior exactly.
- *   'round'              — round half up (the "schoolbook" rule).
- *                          1.235 -> 1.24 for 2-decimal currencies.
- *   'floor'              — round toward 0. Same as `truncate` for the
- *                          non-negative inputs this library accepts.
- *   'ceil'               — round toward +∞. Any non-zero dropped digit
- *                          carries a 1.
- *   'bankers'            — IEEE 754 "round half to even". Reduces
- *                          cumulative bias in long sequences of additions;
- *                          common in financial accounting.
+ *   - `'truncate'` (default) — drop extra digits; preserves v1.1.x behavior.
+ *   - `'round'` — half-up.
+ *   - `'floor'` — same as `'truncate'` for non-negative inputs.
+ *   - `'ceil'` — any non-zero dropped digit carries a 1.
+ *   - `'bankers'` — IEEE 754 half-to-even; reduces accumulator bias.
  */
 export type RoundingMode = 'truncate' | 'round' | 'floor' | 'ceil' | 'bankers';
 
 /**
- * Optional third argument to the Tafgeet constructor.
- *
- * Reserved for future expansion. The current v1.2 release ships only
- * `rounding`; `precision` and other linguistic options (`feminine`,
- * `accusative`, `style`) are planned for v1.3+.
+ * Optional third argument to the Tafgeet constructor. `precision`,
+ * `feminine`, `accusative`, and `style` are planned for v1.3+.
  */
 export interface TafgeetOptions {
   /** See {@link RoundingMode}. Defaults to `'truncate'`. */


### PR DESCRIPTION
Final PR of the v1.2.0 series. Two commits:

1. **`chore: tidy codebase ahead of v1.2.0 release`** — pure cleanup, no behavior changes. Removed:
   - 13-line redundant import-example comment at the top of `src/index.ts`
   - Stale historical "Pre-1.1.0…" tangents in JSDoc
   - Outdated `@throws {Error}` JSDoc on `parse()` (now throws `AmountOutOfRangeError`)
   - The single-call `length()` private method (inlined into `getColumnIndex`)
   - Outdated import example in `src/types.ts` header

   **Net: -31 lines from src/, no logic changes, all 465 tests still pass.**

2. **`chore: release 1.2.0`** — version bump + CHANGELOG entry + README overhaul:
   - `package.json` / `package-lock.json`: 1.1.0 → 1.2.0
   - `CHANGELOG.md`: full v1.2.0 entry following Keep a Changelog format
   - `README.md`:
     - Highlights now showcase v1.2 wins (ESM/CJS, CurrencyCode, Arabic-Indic, errors, rounding)
     - API table updated with the third `options` argument + new Errors discriminated table
     - New "Flexible input formats" and "Rounding" usage sections
     - Imports example expanded to cover the v1.2 surface (`SUPPORTED_CURRENCIES`, error classes, `RoundingMode`, `TafgeetOptions`, `TafgeetErrorCode`)
     - Roadmap bumped to v1.3 (currency registry, `precision`) and v1.4 (grammar — pending native-speaker review)

   **Every README code example was executed against the built `dist/` and output verified byte-identical.**

## Verified

- ✅ `npm run lint` — clean
- ✅ `npm run format:check` — clean
- ✅ `npm run typecheck` — clean
- ✅ `npm test` — **465 passing**
- ✅ `npm run test:js-compat` — CJS + ESM both pass
- ✅ `npm audit` — **0 vulnerabilities**
- ✅ Every README code example verified byte-identical against dist/
- ✅ `npm pack --dry-run` — 17.1 kB tarball, 72.5 kB unpacked

## Package size note

Tarball grew from 7.2 kB (v1.1) → 17.1 kB (v1.2). Breakdown of the increase:
- Custom error classes (~3 kB JS)
- Arabic-Indic + thousands-separator normalization (~1 kB)
- Rounding helpers (~2 kB)
- Richer JSDoc shipped in `.d.ts` files (~9 kB across the dual ESM/CJS d.ts pair)