### PR TITLE
fix: pad short fractions to currency.decimals (real interpretation bug)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,10 @@ export class Tafgeet {
 
   /**
    * Parses the fractional portion.
-   *   - empty/undefined  -> 0
-   *   - length <= decimals  -> literal parse (`'1.2 EGP'` -> 2, not 20;
-   *     historical behavior preserved for backward compat)
+   *   - empty/undefined     -> 0
+   *   - length <= decimals  -> right-pad with zeros to `decimals`, then
+   *     parse. `'1.5 EGP'` -> 50 piasters (NOT 5). `'1.20 TND'` -> 200
+   *     millimes (NOT 20). This matches universal decimal interpretation.
    *   - length >  decimals  -> rounding per `mode`; may carry into the
    *     integer part (`1.995 EGP` with `'round'` -> `2 EGP`).
    */
@@ -71,7 +72,8 @@ export class Tafgeet {
     const decimals = currencies[currency as keyof typeof currencies]?.decimals ?? 2;
 
     if (fracStr.length <= decimals) {
-      return { fracValue: parseInt(fracStr, 10), intCarry: 0 };
+      // Right-pad so `'5'` for EGP -> '50' (50 piasters), not 5 piasters.
+      return { fracValue: parseInt(fracStr.padEnd(decimals, '0'), 10), intCarry: 0 };
     }
 
     const keep = fracStr.slice(0, decimals);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -164,15 +164,19 @@ describe('Reading full amounts', () => {
   it('should read EGP 55,000,051,000', () => {
     assert.equal('خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري فقط لا غير', new Tafgeet('55000051000').parse());
   });
-  it('should read EGP 55,000,051,000.2', () => {
+  it('should read EGP 55,000,051,000.2 (single-digit fraction padded to 20 piasters)', () => {
+    // Pre-1.2.1 this returned '...وٱثنين قرش' (2 piasters) — wrong, since
+    // `.2` decimally means `.20` = 20 piasters. Fixed by right-padding the
+    // fraction string to the currency's decimals before parseInt.
     assert.equal(
-      'خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وٱثنين قرش فقط لا غير',
+      'خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وعشرون قرش فقط لا غير',
       new Tafgeet('55000051000.2').parse(),
     );
   });
-  it('should read EGP 55,000,051,000.1', () => {
+  it('should read EGP 55,000,051,000.1 (single-digit fraction padded to 10 piasters)', () => {
+    // Pre-1.2.1 returned '...وواحد قرش' (1 piaster). Same fix.
     assert.equal(
-      'خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وواحد قرش فقط لا غير',
+      'خمسة وخمسون مليار وواحد وخمسون ألف جنيه مصري وعشرة قروش فقط لا غير',
       new Tafgeet('55000051000.1').parse(),
     );
   });
@@ -208,6 +212,33 @@ describe('Reading full amounts', () => {
   });
   it('should read EGP 2,000,000 (no trailing connector)', () => {
     assert.equal('مليونين جنيه مصري فقط لا غير', new Tafgeet('2000000').parse());
+  });
+
+  // Regression tests for v1.2.1 — short-fraction padding bug.
+  // Inputs with fewer decimal digits than the currency supports must be
+  // right-padded with zeros (`.5 EGP` means 50 piasters, not 5).
+  it('should read EGP 1.5 (single digit padded to 50 piasters)', () => {
+    assert.equal('واحد جنيه مصري وخمسون قرش فقط لا غير', new Tafgeet('1.5').parse());
+  });
+  it('should read EGP 1.3 (single digit padded to 30 piasters)', () => {
+    assert.equal('واحد جنيه مصري وثلاثون قرش فقط لا غير', new Tafgeet('1.3').parse());
+  });
+  it('should read EGP 100.5 (single digit fraction on large amount)', () => {
+    assert.equal('مائة جنيه مصري وخمسون قرش فقط لا غير', new Tafgeet('100.5').parse());
+  });
+  it('should read TND 1.20 (2-digit fraction padded to 200 millimes)', () => {
+    // TND has 3 decimals; "1.20" decimally means "1.200" = 200 millimes.
+    // Pre-1.2.1 returned "واحد دينار تونسي وعشرون مليم" (20 millimes).
+    assert.equal('واحد دينار تونسي ومائتين مليم فقط لا غير', new Tafgeet('1.20', 'TND').parse());
+  });
+  it('should read TND 1.2 (single-digit fraction padded to 200 millimes)', () => {
+    assert.equal('واحد دينار تونسي ومائتين مليم فقط لا غير', new Tafgeet('1.2', 'TND').parse());
+  });
+  it('should read KWD 1.5 (single-digit fraction padded to 500 fils)', () => {
+    assert.equal('واحد دينار كويتي وخمسمائة فلس فقط لا غير', new Tafgeet('1.5', 'KWD').parse());
+  });
+  it('should read KWD 1.05 (2-digit fraction padded to 50 fils)', () => {
+    assert.equal('واحد دينار كويتي وخمسون فلس فقط لا غير', new Tafgeet('1.05', 'KWD').parse());
   });
 
   // Regression tests for the fraction singular/plural bug (the bug behind


### PR DESCRIPTION
**Real bug, not a feature.** v1.0–v1.2 silently interpreted short fractions literally instead of decimally:

| Input | Before | After |
|---|---|---|
| `'1.5'` EGP | `…وخمسة قروش` (5 piasters) | `…وخمسون قرش` (50 piasters) ✓ |
| `'1.20'` TND | `…وعشرون مليم` (20 millimes) | `…ومائتين مليم` (200 millimes) ✓ |
| `'1.5'` KWD | `…وخمسة فلوس` (5 fils) | `…وخمسمائة فلس` (500 fils) ✓ |
| `'55000051000.2'` EGP | `…وٱثنين قرش` (2 piasters) | `…وعشرون قرش` (20 piasters) ✓ |

Wrongly justified in earlier releases as "historical behavior preserved for back-compat." It's just a bug — anyone relying on it was producing financially incorrect output.

## Fix

One-line change in `parseFraction`'s short-fraction branch — pad fracStr to currency.decimals before `parseInt`. Matches universal decimal interpretation where trailing digits represent positional fractions.

## Backward compat

- **Snapshot tests (262 entries) unchanged** — the matrix uses full-length fractions only.
- **2 existing unit tests updated** — they asserted the buggy output for `55000051000.2/.1`. Updated to the correct decimal interpretation.
- Per the precedent set in v1.1.0 for issues #7/#8: "fixing wrong output isn't breaking under semver — it's a patch-level bug fix." Shipping as **1.2.1**.

## Tests

7 new regression tests covering single-digit fractions across 2-decimal (EGP) and 3-decimal (KWD, TND) currencies.

**Total: 472 passing (was 465).**