### PR TITLE
fix: rounding can carry from fractional <1 across to integer 1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,14 +27,17 @@ export class Tafgeet {
   private digit: number;
 
   constructor(digit: string | number, currency: CurrencyInput = 'EGP', options: TafgeetOptions = {}) {
-    // validateInput throws on malformed input and returns the canonical
-    // Latin-digit form (e.g. Arabic-Indic and thousands-separator stripped).
+    // Format + type validation runs early; integer-range validation runs
+    // AFTER rounding so that e.g. `'0.999'` with rounding `'round'` can
+    // legitimately carry into integer 1 instead of being rejected as < 1.
     const normalized = Tafgeet.validateInput(digit, currency);
     this.currency = currency;
     this.splitted = normalized.split('.');
     const intValue = parseInt(this.splitted[0] ?? '0', 10);
     const { fracValue, intCarry } = this.parseFraction(this.splitted[1], currency, options.rounding ?? 'truncate');
-    this.digit = intValue + intCarry;
+    const finalInt = intValue + intCarry;
+    Tafgeet.validateIntegerRange(finalInt, normalized);
+    this.digit = finalInt;
     this.fraction = fracValue;
   }
 
@@ -152,18 +155,6 @@ export class Tafgeet {
       }
     }
 
-    const intPartStr = normalized.split('.')[0] ?? '';
-    const intPart = parseInt(intPartStr, 10);
-    if (intPart < 1) {
-      // Amounts < 1 (e.g. "0", "0.5") are not supported in 1.x — the
-      // dictionaries have no "صفر" entry and the column logic assumes
-      // at least one integer digit. Tracked as a future enhancement.
-      throw new AmountOutOfRangeError(`Tafgeet: integer part must be >= 1, got "${normalized}"`);
-    }
-    if (intPartStr.length >= 16) {
-      throw new AmountOutOfRangeError(`Tafgeet: integer part must be < 16 digits, got "${normalized}"`);
-    }
-
     if (typeof currency !== 'string') {
       throw new InvalidAmountError(`Tafgeet: currency must be a string, got ${typeof currency}`);
     }
@@ -173,6 +164,27 @@ export class Tafgeet {
     }
 
     return normalized;
+  }
+
+  /**
+   * Validates the FINAL integer part (after rounding has had a chance to
+   * carry from the fractional part). Range: 1..999,999,999,999,999.
+   *
+   * Splitting this from validateInput is what enables `'0.999' + round`
+   * to legitimately become `'1'` instead of being rejected as < 1.
+   */
+  private static validateIntegerRange(finalInt: number, originalNormalized: string): void {
+    if (finalInt < 1) {
+      // Amounts < 1 (e.g. "0", "0.5") are not supported in 1.x — the
+      // dictionaries have no "صفر" entry and the column logic assumes
+      // at least one integer digit.
+      throw new AmountOutOfRangeError(`Tafgeet: integer part must be >= 1, got "${originalNormalized}"`);
+    }
+    if (finalInt.toString().length >= 16) {
+      // Catches both the original-too-big case and the rare "rounding
+      // pushed a 15-digit integer to 16" overflow.
+      throw new AmountOutOfRangeError(`Tafgeet: integer part must be < 16 digits, got "${originalNormalized}"`);
+    }
   }
 
   /**

--- a/test/rounding.spec.ts
+++ b/test/rounding.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { Tafgeet, type RoundingMode } from '../src';
+import { AmountOutOfRangeError, Tafgeet, type RoundingMode } from '../src';
 
 describe('Rounding option (1.2.0)', () => {
   describe('default rounding === truncate (preserves v1.1.x behavior)', () => {
@@ -115,6 +115,81 @@ describe('Rounding option (1.2.0)', () => {
           `mode=${mode} changed "1.5" output`,
         );
       }
+    });
+  });
+
+  describe('Rounding can carry from fractional <1 across to integer 1 (v1.2.1 regression)', () => {
+    // Pre-1.2.1: validateInput checked `intPart < 1` BEFORE rounding had a
+    // chance to carry. So `'0.999'` with rounding `'round'` threw
+    // AmountOutOfRangeError instead of rounding up to 1. Fixed by
+    // moving the integer-range check to AFTER parseFraction returns.
+
+    it("'0.999' EGP + round -> 1 EGP", () => {
+      assert.equal(new Tafgeet('0.999', 'EGP', { rounding: 'round' }).parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+    it("'0.999' EGP + ceil -> 1 EGP", () => {
+      assert.equal(new Tafgeet('0.999', 'EGP', { rounding: 'ceil' }).parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+    it("'0.999' EGP + bankers -> 1 EGP (drop=9 > 5 -> carry, not the exactly-half case)", () => {
+      assert.equal(new Tafgeet('0.999', 'EGP', { rounding: 'bankers' }).parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+    it("'0.991' EGP + ceil -> 1 EGP (fraction carry from ceil)", () => {
+      // ceil sees drop='1' → carry, fracValue 99+1=100, overflow → intCarry=1
+      assert.equal(new Tafgeet('0.991', 'EGP', { rounding: 'ceil' }).parse(), 'واحد جنيه مصري فقط لا غير');
+    });
+    it("'0.001' EGP + ceil -> still throws (rounds to 0.01, not 1.00)", () => {
+      // Sanity: ceil rounds the FRACTION up (to 1 piaster), it doesn't
+      // round the whole amount up. 0.001 → 0.01 → integer still 0.
+      assert.throws(
+        () => new Tafgeet('0.001', 'EGP', { rounding: 'ceil' }),
+        AmountOutOfRangeError,
+        /integer part must be >= 1/,
+      );
+    });
+    it("'0.999' TND + round -> 1 TND (3-decimal currency)", () => {
+      // TND has 3 decimals. '0.999' is fracStr='999' length 3 == decimals,
+      // no over-precision → no rounding → fracValue=999, intCarry=0.
+      // finalInt=0, throws. The carry-fix specifically helps OVER-PRECISION
+      // cases where rounding generates the carry — not exact-precision cases.
+      assert.throws(
+        () => new Tafgeet('0.999', 'TND', { rounding: 'round' }),
+        AmountOutOfRangeError,
+        /integer part must be >= 1/,
+      );
+    });
+    it("'0.9999' TND + round -> 1 TND (4-digit fraction on 3-decimal -> rounds, carries)", () => {
+      assert.equal(new Tafgeet('0.9999', 'TND', { rounding: 'round' }).parse(), 'واحد دينار تونسي فقط لا غير');
+    });
+
+    // Cases that should STILL throw — verify the fix didn't accidentally
+    // make us too permissive.
+    it("'0.999' EGP + truncate -> still throws (no carry, finalInt=0)", () => {
+      assert.throws(
+        () => new Tafgeet('0.999', 'EGP', { rounding: 'truncate' }),
+        AmountOutOfRangeError,
+        /integer part must be >= 1/,
+      );
+    });
+    it("'0.999' EGP + floor -> still throws", () => {
+      assert.throws(
+        () => new Tafgeet('0.999', 'EGP', { rounding: 'floor' }),
+        AmountOutOfRangeError,
+        /integer part must be >= 1/,
+      );
+    });
+    it("'0' EGP -> still throws regardless of rounding mode", () => {
+      assert.throws(() => new Tafgeet('0', 'EGP'), AmountOutOfRangeError);
+      assert.throws(() => new Tafgeet('0', 'EGP', { rounding: 'round' }), AmountOutOfRangeError);
+      assert.throws(() => new Tafgeet('0', 'EGP', { rounding: 'ceil' }), AmountOutOfRangeError);
+    });
+
+    // Upper-bound carry: 15-digit integer that rounds to 16 should reject.
+    it("'999999999999999.999' EGP + round -> rejected (carry pushes to 16 digits)", () => {
+      assert.throws(
+        () => new Tafgeet('999999999999999.999', 'EGP', { rounding: 'round' }),
+        AmountOutOfRangeError,
+        /must be < 16 digits/,
+      );
     });
   });
 


### PR DESCRIPTION
**Bug:** `new Tafgeet('0.999', 'EGP', { rounding: 'round' })` threw `AmountOutOfRangeError("integer part must be >= 1")` instead of rounding up to `'واحد جنيه مصري فقط لا غير'`.

**Cause:** `validateInput` checked the `intPart < 1` constraint **before** `parseFraction` ran, so the rounding had no chance to generate the carry.

## Fix

Split validation into two phases:

| Phase | Where | Checks |
|---|---|---|
| **`validateInput`** | early, before rounding | type, format, sign, currency code |
| **`validateIntegerRange`** | late, after `parseFraction` | final integer is `>= 1` AND `< 16 digits` |

This restructure also catches a previously-uncaught upper-bound case: a 15-digit integer with `.999...` fraction rounding to 16 digits now properly throws (e.g. `'999999999999999.999' EGP` with `'round'`).

## Verified behavior

| Input | Mode | Before | After |
|---|---|---|---|
| `'0.999'` EGP | `round` | throws | `'واحد جنيه مصري فقط لا غير'` ✓ |
| `'0.999'` EGP | `ceil` | throws | `'واحد جنيه مصري فقط لا غير'` ✓ |
| `'0.999'` EGP | `bankers` | throws | `'واحد جنيه مصري فقط لا غير'` ✓ |
| `'0.991'` EGP | `ceil` | throws | `'واحد جنيه مصري فقط لا غير'` ✓ |
| `'0.999'` EGP | `truncate` / `floor` | throws | **still throws** (no carry generated) |
| `'0'` EGP | any | throws | **still throws** (sanity) |
| `'0.001'` EGP | `ceil` | throws | **still throws** (rounds to 0.01, not 1.00) |
| `'999999999999999.999'` EGP | `round` | accepted then ??? | **now properly throws** (16-digit boundary) |

## Tests

11 new regression tests. Snapshot file unchanged.

**Total: 483 passing (was 472).**