### PR TITLE
fix: validate options argument strictly (catches 4 silent-failure bugs)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export class Tafgeet {
   private digit: number;
 
   constructor(digit: string | number, currency: CurrencyInput = 'EGP', options: TafgeetOptions = {}) {
+    Tafgeet.validateOptions(options);
     // Format + type validation runs early; integer-range validation runs
     // AFTER rounding so that e.g. `'0.999'` with rounding `'round'` can
     // legitimately carry into integer 1 instead of being rejected as < 1.
@@ -39,6 +40,36 @@ export class Tafgeet {
     Tafgeet.validateIntegerRange(finalInt, normalized);
     this.digit = finalInt;
     this.fraction = fracValue;
+  }
+
+  /**
+   * Validates the optional 3rd constructor argument. Strict: rejects
+   * non-plain-objects, unknown keys (catches typos like `Rounding`),
+   * and invalid `rounding` values. JS callers can pass anything;
+   * this catches the misuses TS would have prevented at compile time.
+   */
+  private static validateOptions(options: unknown): void {
+    if (options === undefined) return; // omitted → use defaults
+    if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+      throw new InvalidAmountError(
+        `Tafgeet: options must be a plain object, got ${options === null ? 'null' : Array.isArray(options) ? 'array' : typeof options}`,
+      );
+    }
+    const allowedKeys = new Set(['rounding']);
+    for (const key of Object.keys(options)) {
+      if (!allowedKeys.has(key)) {
+        throw new InvalidAmountError(`Tafgeet: unknown option "${key}". Supported: ${[...allowedKeys].join(', ')}`);
+      }
+    }
+    const rounding = (options as { rounding?: unknown }).rounding;
+    if (rounding !== undefined) {
+      const allowedModes: ReadonlySet<string> = new Set(['truncate', 'round', 'floor', 'ceil', 'bankers']);
+      if (typeof rounding !== 'string' || !allowedModes.has(rounding)) {
+        throw new InvalidAmountError(
+          `Tafgeet: options.rounding must be one of [${[...allowedModes].join(', ')}], got ${JSON.stringify(rounding)}`,
+        );
+      }
+    }
   }
 
   /**

--- a/test/options-validation.spec.ts
+++ b/test/options-validation.spec.ts
@@ -1,0 +1,150 @@
+import { assert } from 'chai';
+
+import { InvalidAmountError, Tafgeet } from '../src';
+
+describe('Options validation (v1.2.1 hardening)', () => {
+  // Pre-1.2.1: garbage in `options` was either silently ignored, silently
+  // truncated, or crashed with a raw TypeError. JS callers (who ignore TS
+  // types) hit these constantly. v1.2.1 throws a typed InvalidAmountError
+  // with a clear message for every bad shape.
+
+  describe('Rejects malformed options object', () => {
+    it('null throws InvalidAmountError (was raw TypeError "Cannot read properties of null")', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', null as never),
+        InvalidAmountError,
+        /options must be a plain object, got null/,
+      );
+    });
+    it('string throws (was silently ignored)', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', 'oops' as never),
+        InvalidAmountError,
+        /options must be a plain object, got string/,
+      );
+    });
+    it('number throws', () => {
+      assert.throws(
+        () => new Tafgeet('1', 'EGP', 42 as never),
+        InvalidAmountError,
+        /options must be a plain object, got number/,
+      );
+    });
+    it('array throws (arrays are objects but not plain options)', () => {
+      assert.throws(
+        () => new Tafgeet('1', 'EGP', [] as never),
+        InvalidAmountError,
+        /options must be a plain object, got array/,
+      );
+    });
+    it('boolean throws', () => {
+      assert.throws(
+        () => new Tafgeet('1', 'EGP', true as never),
+        InvalidAmountError,
+        /options must be a plain object, got boolean/,
+      );
+    });
+  });
+
+  describe('Rejects unknown keys (catches typos)', () => {
+    it('{ Rounding: ... } (capital R) throws — was silently ignored', () => {
+      assert.throws(
+        () => new Tafgeet('1.999', 'EGP', { Rounding: 'round' } as never),
+        InvalidAmountError,
+        /unknown option "Rounding"\. Supported: rounding/,
+      );
+    });
+    it('{ rounding, foo: "bar" } throws on the extra key', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', { rounding: 'round', foo: 'bar' } as never),
+        InvalidAmountError,
+        /unknown option "foo"/,
+      );
+    });
+    it('{ precision: 2 } (a planned-but-not-yet-implemented option) throws', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', { precision: 2 } as never),
+        InvalidAmountError,
+        /unknown option "precision"/,
+      );
+    });
+  });
+
+  describe('Rejects invalid rounding values', () => {
+    it('{ rounding: "XYZ" } throws — was silently truncating', () => {
+      assert.throws(
+        () => new Tafgeet('1.999', 'EGP', { rounding: 'XYZ' } as never),
+        InvalidAmountError,
+        /options\.rounding must be one of \[truncate, round, floor, ceil, bankers\], got "XYZ"/,
+      );
+    });
+    it('{ rounding: null } throws', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', { rounding: null } as never),
+        InvalidAmountError,
+        /options\.rounding must be one of/,
+      );
+    });
+    it('{ rounding: 42 } throws', () => {
+      assert.throws(
+        () => new Tafgeet('1.5', 'EGP', { rounding: 42 } as never),
+        InvalidAmountError,
+        /options\.rounding must be one of/,
+      );
+    });
+    it('error message lists all valid modes', () => {
+      try {
+        new Tafgeet('1.5', 'EGP', { rounding: 'XYZ' } as never);
+        assert.fail('should have thrown');
+      } catch (e) {
+        const msg = (e as Error).message;
+        for (const mode of ['truncate', 'round', 'floor', 'ceil', 'bankers']) {
+          assert.include(msg, mode, `error message should list "${mode}"`);
+        }
+      }
+    });
+  });
+
+  describe('Accepts valid shapes unchanged', () => {
+    it('omitted options', () => {
+      assert.doesNotThrow(() => new Tafgeet('1', 'EGP'));
+    });
+    it('undefined options', () => {
+      assert.doesNotThrow(() => new Tafgeet('1', 'EGP', undefined));
+    });
+    it('empty object {}', () => {
+      assert.doesNotThrow(() => new Tafgeet('1', 'EGP', {}));
+    });
+    it('{ rounding: undefined } (explicit undefined value)', () => {
+      assert.doesNotThrow(() => new Tafgeet('1', 'EGP', { rounding: undefined }));
+    });
+    it('each valid rounding mode', () => {
+      for (const mode of ['truncate', 'round', 'floor', 'ceil', 'bankers'] as const) {
+        assert.doesNotThrow(
+          () => new Tafgeet('1.5', 'EGP', { rounding: mode }),
+          `rounding: '${mode}' should be accepted`,
+        );
+      }
+    });
+  });
+
+  describe('All errors carry the correct code field', () => {
+    it('every options-validation error has code === "INVALID_AMOUNT"', () => {
+      const cases: Array<() => unknown> = [
+        () => new Tafgeet('1', 'EGP', null as never),
+        () => new Tafgeet('1', 'EGP', 'str' as never),
+        () => new Tafgeet('1', 'EGP', { foo: 'bar' } as never),
+        () => new Tafgeet('1', 'EGP', { rounding: 'XYZ' } as never),
+      ];
+      for (const fn of cases) {
+        try {
+          fn();
+          assert.fail('should have thrown');
+        } catch (e) {
+          assert.instanceOf(e, InvalidAmountError);
+          assert.equal((e as InvalidAmountError).code, 'INVALID_AMOUNT');
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
The optional 3rd constructor argument was a silent-failure zone for JS callers (TS users were protected at compile time; JS users had no signal at all):

| Input | Before | After |
|---|---|---|
| `{ rounding: 'XYZ' }` | silently truncated | `InvalidAmountError`: "must be one of [truncate, round, …]" |
| `'oops'` (string) | silently ignored | `InvalidAmountError`: "options must be a plain object" |
| `null` | raw `TypeError: Cannot read properties of null` | `InvalidAmountError` (typed, with code) |
| `{ Rounding: 'round' }` (capital R) | silently used default | `InvalidAmountError`: "unknown option \"Rounding\"" |
| `42`, `true`, `[]` | varied silent failures | `InvalidAmountError` (typed) |

## Implementation

New private static `Tafgeet.validateOptions(options: unknown)` called before any options access. Rejects:
- `null`, non-objects, arrays
- Unknown keys (strict — catches typos AND forward-compat attempts like `{ precision: 2 }`)
- Invalid `rounding` values (must be one of the 5 known modes)

**No new error class.** Reuses `InvalidAmountError` — same code (`'INVALID_AMOUNT'`). Error message includes the option name and lists valid values.

## Backward compat

- All existing valid options unchanged
- Snapshot tests unchanged (don't pass options)
- `omitted`, `{}`, `undefined` all still accepted

## Tests

**18 new tests** covering: 5 malformed-object cases, 3 unknown-key cases, 4 invalid-rounding-value cases, 5 valid-shape sanity checks, 1 code-field invariant check.

**Total: 501 passing (was 483).**