### PR TITLE
fix: trim currency + reject fractional input in no-currency mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,26 @@ export class Tafgeet {
 
   constructor(digit: string | number, currency: CurrencyInput = 'EGP', options: TafgeetOptions = {}) {
     Tafgeet.validateOptions(options);
+    // Trim whitespace from currency for consistency with the amount
+    // (which is also trimmed during normalization). `' EGP '` works.
+    const trimmedCurrency = typeof currency === 'string' ? currency.trim() : currency;
     // Format + type validation runs early; integer-range validation runs
     // AFTER rounding so that e.g. `'0.999'` with rounding `'round'` can
     // legitimately carry into integer 1 instead of being rejected as < 1.
-    const normalized = Tafgeet.validateInput(digit, currency);
-    this.currency = currency;
+    const normalized = Tafgeet.validateInput(digit, trimmedCurrency);
+    // validateInput guarantees trimmedCurrency is now a string.
+    this.currency = trimmedCurrency as string;
     this.splitted = normalized.split('.');
+    // No-currency mode silently dropped fractional input pre-1.2.1.
+    // Now: reject up front (the user clearly intended fractional rendering
+    // but no-currency mode has no fraction word to render with).
+    if (this.currency === '' && /[1-9]/.test(this.splitted[1] ?? '')) {
+      throw new InvalidAmountError(
+        `Tafgeet: no-currency mode does not accept fractional amounts (no fraction word to render), got "${normalized}". Pass an integer amount, or specify a currency.`,
+      );
+    }
     const intValue = parseInt(this.splitted[0] ?? '0', 10);
-    const { fracValue, intCarry } = this.parseFraction(this.splitted[1], currency, options.rounding ?? 'truncate');
+    const { fracValue, intCarry } = this.parseFraction(this.splitted[1], this.currency, options.rounding ?? 'truncate');
     const finalInt = intValue + intCarry;
     Tafgeet.validateIntegerRange(finalInt, normalized);
     this.digit = finalInt;

--- a/test/currency-and-nocurrency.spec.ts
+++ b/test/currency-and-nocurrency.spec.ts
@@ -1,0 +1,80 @@
+import { assert } from 'chai';
+
+import { InvalidAmountError, Tafgeet, UnsupportedCurrencyError } from '../src';
+
+describe('Currency trim (v1.2.1)', () => {
+  // Pre-1.2.1: amount strings were trimmed, but currency strings weren't —
+  // so ' EGP ' threw UnsupportedCurrencyError even though 'EGP' is valid.
+  // Now trimmed for consistency.
+
+  it("trims leading/trailing space: ' EGP '", () => {
+    assert.equal(new Tafgeet('1', ' EGP ').parse(), new Tafgeet('1', 'EGP').parse());
+  });
+  it('trims tabs and newlines: "\\tEGP\\n"', () => {
+    assert.equal(new Tafgeet('1', '\tEGP\n').parse(), new Tafgeet('1', 'EGP').parse());
+  });
+  it("whitespace-only currency is treated as no-currency mode (trims to '')", () => {
+    assert.equal(new Tafgeet('100', '   ').parse(), new Tafgeet('100', '').parse());
+  });
+  it('still rejects truly-unknown currencies after trim', () => {
+    assert.throws(() => new Tafgeet('1', ' BTC '), UnsupportedCurrencyError, /unknown currency/);
+  });
+  it('trim preserves backward compat for already-clean codes', () => {
+    for (const code of ['EGP', 'SAR', 'KWD', 'USD'] as const) {
+      assert.doesNotThrow(() => new Tafgeet('1', code));
+    }
+  });
+});
+
+describe('No-currency mode rejects fractional input (v1.2.1)', () => {
+  // Pre-1.2.1: `new Tafgeet('1.50', '')` silently dropped the .50 and
+  // returned 'واحد فقط لا غير' (just "one"). Now: throws so the user
+  // sees their input was incompatible with no-currency mode.
+
+  describe('rejects', () => {
+    it("'1.50' in no-currency mode throws", () => {
+      assert.throws(
+        () => new Tafgeet('1.50', ''),
+        InvalidAmountError,
+        /no-currency mode does not accept fractional amounts/,
+      );
+    });
+    it("'1.001' in no-currency mode throws (any non-zero fraction)", () => {
+      assert.throws(() => new Tafgeet('1.001', ''), InvalidAmountError);
+    });
+    it("'100.5' in no-currency mode throws", () => {
+      assert.throws(() => new Tafgeet('100.5', ''), InvalidAmountError);
+    });
+    it('the error message guides toward a fix', () => {
+      try {
+        new Tafgeet('1.50', '');
+        assert.fail('should have thrown');
+      } catch (e) {
+        const msg = (e as Error).message;
+        assert.include(msg, 'integer', 'should mention "Pass an integer"');
+        assert.include(msg, 'currency', 'should mention "specify a currency"');
+      }
+    });
+  });
+
+  describe('accepts (no fractional content present)', () => {
+    it("'1' in no-currency mode — pure integer", () => {
+      assert.equal(new Tafgeet('1', '').parse(), 'واحد فقط لا غير');
+    });
+    it("'1.0' in no-currency mode — all-zero fraction (effectively integer)", () => {
+      assert.equal(new Tafgeet('1.0', '').parse(), 'واحد فقط لا غير');
+    });
+    it("'1.00' in no-currency mode — all-zero fraction", () => {
+      assert.equal(new Tafgeet('1.00', '').parse(), 'واحد فقط لا غير');
+    });
+    it("'1.000' in no-currency mode — all-zero fraction", () => {
+      assert.equal(new Tafgeet('1.000', '').parse(), 'واحد فقط لا غير');
+    });
+    it("'7564654' in no-currency mode (regression — existing test)", () => {
+      assert.equal(
+        new Tafgeet('7564654', '').parse(),
+        'سبعة ملايين وخمسمائة وأربعة وستون ألف وستمائة وأربعة وخمسون فقط لا غير',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Two small consistency fixes bundled — both touch the same constructor flow.

## Fix 1 — currency whitespace trim

| Input | Before | After |
|---|---|---|
| `new Tafgeet('1', ' EGP ')` | `UnsupportedCurrencyError` | works, parses as `EGP` ✓ |
| `new Tafgeet('1', '\tEGP\n')` | error | works ✓ |
| `new Tafgeet('100', '   ')` | error | works (whitespace-only → no-currency mode) ✓ |

The amount was trimmed during normalization but currency wasn't — asymmetric. Real-world inputs from forms / CSVs / spreadsheets often have stray whitespace.

## Fix 2 — no-currency mode rejects fractional input

| Input | Before | After |
|---|---|---|
| `new Tafgeet('1.50', '')` | `'واحد فقط لا غير'` (the `.50` **silently dropped**) | `InvalidAmountError` ✓ |
| `new Tafgeet('1.001', '')` | silently truncated to `'واحد'` | `InvalidAmountError` ✓ |
| `new Tafgeet('1.0', '')` | works | still works (all-zero fraction is "effectively integer") ✓ |
| `new Tafgeet('1.00', '')` | works | still works ✓ |
| `new Tafgeet('7564654', '')` | works | still works (no fraction) ✓ |

No-currency mode has no fraction word to render. Silently dropping decimal input is data loss without warning. Now rejects up front with a message that guides the user to either pass an integer or specify a currency.

**Lenient about all-zero fractions** — `'1.0'`, `'1.00'`, `'1.000'` all accepted as "effectively integer" since these are common from spreadsheets.

## Backward compatibility

- Snapshot tests unchanged (262 entries pinned, all still match)
- All previously-correct inputs still work
- Only previously-silent-failure inputs now throw

## Tests

14 new: 5 trim cases + 9 no-currency cases (incl. 5 sanity checks for accepted shapes).

**Total: 515 passing (was 501).**