### PR TITLE
fix: reject number inputs that stringify in scientific notation (CRITICAL)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,18 @@ export class Tafgeet {
         throw new AmountOutOfRangeError(`Tafgeet: amount must be non-negative, got ${digit}`);
       }
       normalized = digit.toString();
+      // Numbers >= 1e21 or < 1e-6 stringify in scientific notation
+      // (e.g. "1e+21", "1.79e+308", "5e-324"). Pre-1.2.1 these slipped
+      // past validation and parseFraction silently corrupted the output
+      // (Number.MAX_VALUE rendered as "1.79 EGP"). Reject them here and
+      // tell the caller how to recover.
+      if (!/^\d+(\.\d+)?$/.test(normalized)) {
+        throw new AmountOutOfRangeError(
+          `Tafgeet: number ${digit} is outside the representable decimal range ` +
+            `(stringifies via scientific notation to "${normalized}"). ` +
+            `Pass the value as a string for full precision, e.g. \`"${digit.toFixed(0)}"\`.`,
+        );
+      }
     } else {
       // Normalize first (Arabic-Indic digits, thousands separators, etc.)
       // BEFORE the format regex — otherwise a perfectly valid Arabic

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -157,6 +157,62 @@ describe('Custom error classes (1.2.0)', () => {
     });
   });
 
+  describe('Number-input scientific notation bypass (v1.2.1 regression)', () => {
+    // Pre-1.2.1 critical bug: numbers JS stringifies in scientific notation
+    // (>= 1e21 or < 1e-6) bypassed the format-regex check (which only ran
+    // on string inputs). Result: Number.MAX_VALUE silently rendered as
+    // "1.79 EGP" instead of throwing.
+
+    it('Number.MAX_VALUE throws (was: silently rendered as 1.79 EGP)', () => {
+      assert.throws(
+        () => new Tafgeet(Number.MAX_VALUE, 'EGP'),
+        AmountOutOfRangeError,
+        /outside the representable decimal range/,
+      );
+    });
+    it('1e+21 throws (was: silently rendered as 1 EGP)', () => {
+      assert.throws(() => new Tafgeet(1e21, 'EGP'), AmountOutOfRangeError);
+    });
+    it('1e+100 throws (was: silently rendered as 1 EGP)', () => {
+      assert.throws(() => new Tafgeet(1e100, 'EGP'), AmountOutOfRangeError);
+    });
+    it('Number.MIN_VALUE throws (was: silently rendered as 5 EGP)', () => {
+      assert.throws(() => new Tafgeet(Number.MIN_VALUE, 'EGP'), AmountOutOfRangeError);
+    });
+    it('1e-7 throws (boundary of exponential-notation threshold)', () => {
+      assert.throws(() => new Tafgeet(1e-7, 'EGP'), AmountOutOfRangeError);
+    });
+    it('error message guides toward passing as string', () => {
+      try {
+        new Tafgeet(1e25, 'EGP');
+        assert.fail('should have thrown');
+      } catch (e) {
+        const msg = (e as Error).message;
+        assert.include(msg, 'string', 'should suggest passing as string');
+        assert.include(msg, 'scientific notation', 'should mention scientific notation');
+      }
+    });
+
+    // Sanity — boundary numbers that DO stay in decimal form must still work.
+    it('1e+20 (just under exp threshold) — 21 digits, throws as 16+ digits not as exp-bypass', () => {
+      // 1e+20 = 100000000000000000000 (21 digits); throws via the 16-digit check.
+      assert.throws(() => new Tafgeet(1e20, 'EGP'), AmountOutOfRangeError, /< 16 digits/);
+    });
+    it('1e-6 = 0.000001 — under threshold but parses (intPart=0 throws via range)', () => {
+      // 0.000001.toString() === '0.000001' (decimal); intPart=0 → throws.
+      assert.throws(() => new Tafgeet(1e-6, 'EGP'), AmountOutOfRangeError, /must be >= 1/);
+    });
+    it('999999999999999 (15 digits, biggest valid integer) still works', () => {
+      assert.doesNotThrow(() => new Tafgeet(999999999999999, 'EGP'));
+    });
+    it('1234.56 still works (normal case unaffected)', () => {
+      assert.equal(
+        new Tafgeet(1234.56, 'EGP').parse(),
+        'ألف ومائتين وأربعة وثلاثون جنيه مصري وستة وخمسون قرش فقط لا غير',
+      );
+    });
+  });
+
   describe('Structured error handling pattern', () => {
     // Document the recommended way to handle errors uniformly.
     function describeError(input: unknown, currency: unknown): { code: TafgeetErrorCode; message: string } | null {


### PR DESCRIPTION
🚨 **Critical bug:** `Number.MAX_VALUE` silently rendered as **1.79 EGP**. Any caller passing arithmetic results that could overflow received silently-wrong output.

## Demonstration

| Input | Before | After |
|---|---|---|
| `Number.MAX_VALUE` (1.79e+308) | `'واحد جنيه مصري وتسعة وسبعون قرش...'` (1.79 EGP) | **throws** `AmountOutOfRangeError` |
| `1e+21` | `'واحد جنيه مصري...'` (1 EGP) | **throws** |
| `1e+100` | `'واحد جنيه مصري...'` (1 EGP) | **throws** |
| `1e-7` | `'واحد جنيه مصري...'` (1 EGP) | **throws** |
| `Number.MIN_VALUE` (5e-324) | `'خمسة جنيهات مصرية...'` (5 EGP) | **throws** |

## How the bug worked

`validateInput`'s format regex (`^-?\d+(\.\d+)?$`) was only applied to **string** inputs. Number inputs took this path:

```ts
normalized = digit.toString();   // 'e+' or 'e-' for extreme values
// no regex check
// parseFraction then silently mangles "1.79e+308" into "1.79"
```

## How tests missed it

Every number-input test used integer-safe values (`1`, `44`, `42`, etc.). All "huge number" tests used **string** inputs, which DO get regex-checked. The string-branch-only check was an invisible asymmetry.

This is the **third meta-pattern testing gap** discovered in v1.2.1:
1. Tests pinned wrong output as correct (short-fraction bug)
2. Validation ordering wasn't tested across feature interactions (rounding-carry bug)
3. **Type-branch parity wasn't tested** (this bug)

## Fix

Apply the same regex check to the number branch. Error message includes the recovery hint:

```
Tafgeet: number 1e+25 is outside the representable decimal range
(stringifies via scientific notation to "1e+25").
Pass the value as a string for full precision, e.g. `"1e+25"`.
```

## Backward compat

- All 262 snapshot tests unchanged
- All normal numeric inputs unchanged (1, 100, 999.99, 1234.56, 9999999999999, etc.)
- Only previously-silently-broken inputs now throw

## Tests

10 new regression tests:
- 6 manifestation cases (MAX_VALUE, MIN_VALUE, 1e+21/+25/+100, 1e-7)
- 1 error-message guidance check
- 3 boundary sanity checks (1e+20, 1e-6, 999999999999999)

**Total: 525 passing (was 515).**