### PR TITLE
fix: harden public methods (read input validation + parse state validation)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,13 @@ export class Tafgeet {
    */
   parse(): string {
     const intStr = this.digit.toString();
+    // Re-validate the internal state — guards against post-construction
+    // mutation (private fields are TS-only, accessible at runtime via
+    // reflection). The constructor already validates these, so this only
+    // fires if someone mutated `this.digit` between construction and parse.
+    if (!Number.isInteger(this.digit) || this.digit < 1) {
+      throw new AmountOutOfRangeError(`Tafgeet: integer part must be >= 1, got ${this.digit}`);
+    }
     if (intStr.length >= 16) {
       throw new AmountOutOfRangeError('Tafgeet: integer part must be < 16 digits');
     }
@@ -306,12 +313,23 @@ export class Tafgeet {
    * Renders a value 0–999 as Arabic words (without any column/currency suffix).
    * Exposed publicly for use as a low-level helper; for whole amounts, use
    * `parse()` instead.
+   *
+   * `0` returns `''` (no Arabic word for zero in this dictionary).
+   *
+   * @throws {InvalidAmountError} if `d` is not a finite integer
+   * @throws {AmountOutOfRangeError} if `d` is outside the `0..999` range
    */
   read(d: number): string {
+    if (typeof d !== 'number' || !Number.isFinite(d) || !Number.isInteger(d)) {
+      throw new InvalidAmountError(`Tafgeet.read: argument must be a finite integer, got ${String(d)}`);
+    }
+    if (d < 0 || d > 999) {
+      throw new AmountOutOfRangeError(`Tafgeet.read: argument must be in 0..999, got ${d}`);
+    }
+    if (d === 0) return '';
     if (d < 10) return this.readOnes(d);
     if (d < 100) return this.readTens(d);
-    if (d < 1000) return this.readHundreds(d);
-    return '';
+    return this.readHundreds(d);
   }
 
   // Maps digit-count of the integer part -> starting column index.

--- a/test/hardening.spec.ts
+++ b/test/hardening.spec.ts
@@ -1,0 +1,127 @@
+import { assert } from 'chai';
+
+import { AmountOutOfRangeError, InvalidAmountError, Tafgeet } from '../src';
+
+describe('read() input validation (v1.2.1 — Bug B)', () => {
+  // Pre-1.2.1: read() silently returned '' for any invalid input.
+  // Docs said "0–999"; out-of-range / wrong-type calls were silent
+  // failures. Now: throws typed errors.
+
+  const t = new Tafgeet('1', 'EGP'); // any instance — read() is shared
+
+  describe('accepts valid inputs', () => {
+    it('read(0) returns empty string (no Arabic word for zero)', () => {
+      assert.equal(t.read(0), '');
+    });
+    it('read(1) returns واحد', () => {
+      assert.equal(t.read(1), 'واحد');
+    });
+    it('read(42) returns ٱثنين وأربعون', () => {
+      assert.equal(t.read(42), 'ٱثنين وأربعون');
+    });
+    it('read(100) returns مائة', () => {
+      assert.equal(t.read(100), 'مائة');
+    });
+    it('read(999) returns تسعمائة وتسعة وتسعون', () => {
+      assert.equal(t.read(999), 'تسعمائة وتسعة وتسعون');
+    });
+  });
+
+  describe('throws AmountOutOfRangeError for out-of-range', () => {
+    it('read(-1) throws (was: silent "")', () => {
+      assert.throws(() => t.read(-1), AmountOutOfRangeError, /must be in 0\.\.999, got -1/);
+    });
+    it('read(1000) throws (was: silent "")', () => {
+      assert.throws(() => t.read(1000), AmountOutOfRangeError, /must be in 0\.\.999, got 1000/);
+    });
+    it('read(99999) throws', () => {
+      assert.throws(() => t.read(99999), AmountOutOfRangeError);
+    });
+  });
+
+  describe('throws InvalidAmountError for non-integer / non-number', () => {
+    it('read(1.5) throws (was: silent "")', () => {
+      assert.throws(() => t.read(1.5), InvalidAmountError, /must be a finite integer/);
+    });
+    it('read(NaN) throws (was: silent "")', () => {
+      assert.throws(() => t.read(NaN), InvalidAmountError);
+    });
+    it('read(Infinity) throws (was: silent "")', () => {
+      assert.throws(() => t.read(Infinity), InvalidAmountError);
+    });
+    it('read(-Infinity) throws', () => {
+      assert.throws(() => t.read(-Infinity), InvalidAmountError);
+    });
+    it('read("42") throws (string not accepted; was: silent "")', () => {
+      assert.throws(() => t.read('42' as never), InvalidAmountError);
+    });
+    it('read("abc") throws', () => {
+      assert.throws(() => t.read('abc' as never), InvalidAmountError);
+    });
+    it('read(null) throws', () => {
+      assert.throws(() => t.read(null as never), InvalidAmountError);
+    });
+    it('read(undefined) throws', () => {
+      assert.throws(() => t.read(undefined as never), InvalidAmountError);
+    });
+    it('read({}) throws', () => {
+      assert.throws(() => t.read({} as never), InvalidAmountError);
+    });
+  });
+});
+
+describe('parse() validates internal state (v1.2.1 — Bug C)', () => {
+  // Pre-1.2.1: parse() trusted that this.digit was still valid. Anyone
+  // mutating it via reflection (TS-private is not runtime-private) could
+  // produce broken output like " جنيه مصري فقط لا غير" (leading space,
+  // no number). Now: parse() re-validates this.digit's lower bound + integer-ness.
+  // (Upper bound was already checked.)
+
+  describe('throws if this.digit was mutated to invalid state', () => {
+    it('digit = 0 → throws AmountOutOfRangeError (was: " جنيه مصري...")', () => {
+      const t = new Tafgeet('1', 'EGP');
+      // TS hides this; JS allows it. Reflection use.
+      (t as unknown as { digit: number }).digit = 0;
+      assert.throws(() => t.parse(), AmountOutOfRangeError, /integer part must be >= 1, got 0/);
+    });
+    it('digit = -5 → throws', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { digit: number }).digit = -5;
+      assert.throws(() => t.parse(), AmountOutOfRangeError, />= 1/);
+    });
+    it('digit = 1.5 → throws (non-integer)', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { digit: number }).digit = 1.5;
+      assert.throws(() => t.parse(), AmountOutOfRangeError, />= 1, got 1.5/);
+    });
+    it('digit = NaN → throws (non-integer)', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { digit: number }).digit = NaN;
+      assert.throws(() => t.parse(), AmountOutOfRangeError);
+    });
+    it('digit = Infinity → throws', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { digit: number }).digit = Infinity;
+      assert.throws(() => t.parse(), AmountOutOfRangeError);
+    });
+    it('digit = huge (16+ digits) → still throws via existing upper-bound check', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { digit: number }).digit = 100000000000000000;
+      assert.throws(() => t.parse(), AmountOutOfRangeError, /< 16 digits/);
+    });
+  });
+
+  describe('parse() still idempotent and unaffected on valid state', () => {
+    it('repeated parse() returns same output', () => {
+      const t = new Tafgeet('1234.56', 'EGP');
+      assert.equal(t.parse(), t.parse());
+      assert.equal(t.parse(), t.parse()); // three calls just to be sure
+    });
+    it('normal construction → valid parse()', () => {
+      assert.equal(
+        new Tafgeet('1234.56', 'EGP').parse(),
+        'ألف ومائتين وأربعة وثلاثون جنيه مصري وستة وخمسون قرش فقط لا غير',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Two related public-method gaps from the v1.2.1 audit.

## Bug B — `read()` silently returned `''` for invalid input

| Input | Before | After |
|---|---|---|
| `t.read(-1)` | `''` (silent) | `AmountOutOfRangeError`: "must be in 0..999, got -1" |
| `t.read(1000)` | `''` | `AmountOutOfRangeError`: "must be in 0..999, got 1000" |
| `t.read(1.5)` | `''` | `InvalidAmountError`: "must be a finite integer, got 1.5" |
| `t.read(NaN)` | `''` | `InvalidAmountError` |
| `t.read(Infinity)` | `''` | `InvalidAmountError` |
| `t.read('abc')` | `''` | `InvalidAmountError` |
| `t.read(null)` | `''` | `InvalidAmountError` |
| `t.read(0)` | `''` | **still `''`** (documented — no Arabic word for zero) |
| `t.read(1..999)` | works | **still works** |

`read()` is publicly documented as "0–999"; out-of-range / wrong-type calls were silent failures.

## Bug C — `parse()` didn't re-validate `this.digit` after mutation

| Scenario | Before | After |
|---|---|---|
| `t.digit = 0; t.parse()` | `' جنيه مصري فقط لا غير'` (leading space, broken) | `AmountOutOfRangeError`: "must be >= 1, got 0" |
| `t.digit = -5; t.parse()` | broken output | throws |
| `t.digit = 1.5; t.parse()` | broken output (Math.floor weirdness) | throws |
| `t.digit = NaN; t.parse()` | broken | throws |
| `t.digit = huge; t.parse()` | already threw (upper bound was checked) | unchanged |

This is reflection-misuse territory — TS private fields aren't runtime-private — so it's **defense in depth**, not a normal-API fix. But the cost is one cheap check and the payoff is a clear error instead of garbage output.

## Backward compat

- Snapshot tests unchanged (262 entries)
- Normal `parse()` and `read(0..999)` calls unchanged
- Only previously-silent-failure calls now throw

## Tests

25 new: 10 read-validation + 6 read-out-of-range + 6 parse-state-mutation + 3 sanity checks.

**Total: 550 passing (was 525).**