### PR TITLE
fix: parse() validates currency state too (Bug D from 2nd audit)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -254,13 +254,19 @@ export class Tafgeet {
     const intStr = this.digit.toString();
     // Re-validate the internal state — guards against post-construction
     // mutation (private fields are TS-only, accessible at runtime via
-    // reflection). The constructor already validates these, so this only
-    // fires if someone mutated `this.digit` between construction and parse.
+    // reflection). The constructor already validates these, so these only
+    // fire if someone mutated state between construction and parse.
     if (!Number.isInteger(this.digit) || this.digit < 1) {
       throw new AmountOutOfRangeError(`Tafgeet: integer part must be >= 1, got ${this.digit}`);
     }
     if (intStr.length >= 16) {
       throw new AmountOutOfRangeError('Tafgeet: integer part must be < 16 digits');
+    }
+    if (typeof this.currency !== 'string') {
+      throw new InvalidAmountError(`Tafgeet: currency must be a string, got ${typeof this.currency}`);
+    }
+    if (this.currency !== '' && !(this.currency in currencies)) {
+      throw new UnsupportedCurrencyError(`Tafgeet: unknown currency "${this.currency}"`);
     }
 
     let str = '';

--- a/test/hardening.spec.ts
+++ b/test/hardening.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { AmountOutOfRangeError, InvalidAmountError, Tafgeet } from '../src';
+import { AmountOutOfRangeError, InvalidAmountError, Tafgeet, UnsupportedCurrencyError } from '../src';
 
 describe('read() input validation (v1.2.1 — Bug B)', () => {
   // Pre-1.2.1: read() silently returned '' for any invalid input.
@@ -122,6 +122,37 @@ describe('parse() validates internal state (v1.2.1 — Bug C)', () => {
         new Tafgeet('1234.56', 'EGP').parse(),
         'ألف ومائتين وأربعة وثلاثون جنيه مصري وستة وخمسون قرش فقط لا غير',
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Bug D — found in the 2nd-pass audit. Symmetric to Bug C but for currency.
+  // ---------------------------------------------------------------------------
+  describe('parse() validates currency state (v1.2.1 — Bug D)', () => {
+    it('mutated currency = unregistered string → UnsupportedCurrencyError (was: raw TypeError)', () => {
+      const t = new Tafgeet('1.50', 'EGP');
+      (t as unknown as { currency: string }).currency = 'INVALID';
+      assert.throws(() => t.parse(), UnsupportedCurrencyError, /unknown currency "INVALID"/);
+    });
+    it('mutated currency = number → InvalidAmountError (was: raw TypeError)', () => {
+      const t = new Tafgeet('1.50', 'EGP');
+      (t as unknown as { currency: number }).currency = 42;
+      assert.throws(() => t.parse(), InvalidAmountError, /currency must be a string/);
+    });
+    it('mutated currency = null → InvalidAmountError', () => {
+      const t = new Tafgeet('1.50', 'EGP');
+      (t as unknown as { currency: null }).currency = null;
+      assert.throws(() => t.parse(), InvalidAmountError, /currency must be a string/);
+    });
+    it('mutated currency = SAR (valid) still works (only invalid state throws)', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { currency: string }).currency = 'SAR';
+      assert.equal(t.parse(), 'واحد ريال سعودي فقط لا غير');
+    });
+    it('mutated currency = "" → no-currency mode still works', () => {
+      const t = new Tafgeet('1', 'EGP');
+      (t as unknown as { currency: string }).currency = '';
+      assert.equal(t.parse(), 'واحد فقط لا غير');
     });
   });
 });


### PR DESCRIPTION
Found during the 2nd-pass audit. Symmetrical to **Bug C** (digit mutation) but for currency mutation.

## Before

```js
const t = new Tafgeet('1.50', 'EGP');
t.currency = 'INVALID';
t.parse();
// → raw TypeError: Cannot read properties of undefined (reading 'singular')
```

## After

| Mutation | Result |
|---|---|
| `currency = 'INVALID'` | `UnsupportedCurrencyError: unknown currency "INVALID"` |
| `currency = 42` | `InvalidAmountError: currency must be a string, got number` |
| `currency = null` | `InvalidAmountError: currency must be a string, got object` |
| `currency = 'SAR'` (valid mutation) | **still works** → `'واحد ريال سعودي فقط لا غير'` |
| `currency = ''` (no-currency mode) | **still works** |

## How tests missed it

PR 6 (Bugs B+C) only validated `this.digit`. I focused on digit-mutation when designing the defense and didn't think about the symmetric currency case. The 2nd-pass audit caught it.

**Meta-lesson:** "defense in depth" requires symmetric defenses across all mutable states, not just the obvious field. Adding a per-PR checklist: "for every state field this PR validates, what are the parallel fields?"

## Backward compatibility

- Snapshot tests unchanged (262 entries)
- Normal parse() unchanged
- Valid mutations (`currency = 'SAR'`) still work
- Only invalid mutations now throw cleanly instead of crashing

## Tests

5 new: 3 invalid-mutation cases + 2 valid-mutation sanity checks.

**Total: 555 passing (was 550).**