### PR TITLE
chore: release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,80 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] – 2026-05-28
+
+A patch release of correctness, hardening, and safety fixes. Eight distinct
+bugs found across two audit passes. **No new APIs, no new options, no
+breaking changes for any input that was previously correctly handled.**
+Some previously-silent-failure inputs now throw clear typed errors instead.
+
+### Fixed
+
+- **Short fractions now correctly pad to currency precision** (real
+  interpretation bug, was wrongly justified as "back-compat"):
+  - `'1.5' EGP` before: `…وخمسة قروش` (5 piasters)
+    → after: `…وخمسون قرش` (50 piasters)
+  - `'1.20' TND` before: `…وعشرون مليم` (20 millimes)
+    → after: `…ومائتين مليم` (200 millimes)
+  - `'1.5' KWD` before: `…وخمسة فلوس` (5 fils)
+    → after: `…وخمسمائة فلس` (500 fils)
+  - Matches universal decimal interpretation — `.5` means half of the unit,
+    not 5 of the smallest atomic unit.
+- **Rounding can now carry from `<1` into `1`.** `new Tafgeet('0.999',
+  'EGP', { rounding: 'round' })` used to throw `AmountOutOfRangeError`
+  because integer-range validation ran BEFORE rounding had a chance to
+  carry. Now correctly renders `'واحد جنيه مصري فقط لا غير'`. Validation
+  was split into format-check (early) and integer-range-check (after
+  rounding).
+- **CRITICAL: number inputs that stringify in scientific notation no longer
+  silently corrupt.** Pre-1.2.1, `Number.MAX_VALUE` (≈1.79×10³⁰⁸)
+  rendered as `'1.79 EGP'`. Any number ≥ 1e21 or < 1e-6 (which JS
+  stringifies as `'1e+21'`, etc.) silently slipped past the format
+  regex because the regex was only applied to string inputs. Now throws
+  `AmountOutOfRangeError` with a helpful "pass as string" hint.
+  Affected magnitudes:
+  - `1e+21` and larger numbers
+  - `1e-7` and smaller numbers
+  - `Number.MAX_VALUE`, `Number.MIN_VALUE`
+- **No-currency mode rejects fractional input.** `new Tafgeet('1.50',
+  '').parse()` previously silently dropped the `.50` and returned
+  `'واحد فقط لا غير'`. Now throws `InvalidAmountError` with a message
+  suggesting either an integer amount or a currency code. Lenient on
+  all-zero fractions (`'1.0'`, `'1.00'`) for spreadsheet compatibility.
+- **Currency argument is now trimmed** for consistency with the amount.
+  `new Tafgeet('1', ' EGP ')` used to throw `UnsupportedCurrencyError`;
+  now works. Whitespace-only currency trims to `''` (no-currency mode).
+- **Options validation is now strict.** Pre-1.2.1, garbage in the third
+  constructor argument was silently ignored or crashed with raw
+  `TypeError`s:
+  - `{ rounding: 'XYZ' }` silently truncated → now throws with valid mode list
+  - `'string'`, `42`, `null`, arrays as options → silent/crash → now throws
+  - `{ Rounding: 'round' }` (capital R typo) silently used default → now throws
+  - `{ precision: 2 }` (option that doesn't exist yet) silently ignored → now throws
+- **`read()` validates its input.** Previously `read(-1)`, `read(1.5)`,
+  `read(1000)`, `read(NaN)`, `read('abc')` all silently returned `''`.
+  Now throws `InvalidAmountError` (wrong type / non-integer) or
+  `AmountOutOfRangeError` (outside 0..999). `read(0)` continues to
+  return `''` as documented.
+- **`parse()` re-validates internal state** (defense in depth against
+  reflection-based mutation of `private` fields). Previously,
+  `instance.digit = 0; instance.parse()` returned `' جنيه مصري فقط لا غير'`
+  (broken). Same applied for currency mutation. Both now throw typed errors.
+
+### Internal
+
+- 90 new regression tests across all 8 fixes. Total test count:
+  **555 passing** (was 465 at v1.2.0). Snapshot file unchanged.
+- Each fix shipped as its own PR with focused diff and dedicated tests.
+
+### Compatibility note for callers
+
+The fixes change output behavior only for inputs that were previously
+producing **wrong** output or **silently failing** — never for inputs
+that were correctly handled. If you have existing tests that asserted
+on outputs for `'1.5'`-style short fractions or numbers like
+`Number.MAX_VALUE`, those tests were pinning bugs and need updating.
+
 ## [1.2.0] – 2026-05-28
 
 A packaging, types, and ergonomics release. **No breaking API changes.**

--- a/README.md
+++ b/README.md
@@ -229,6 +229,63 @@ try {
 }
 ```
 
+## Common pitfalls
+
+Things that surprise users — most are guarded by typed errors since v1.2.1, but worth knowing up front.
+
+### Pass strings for amounts you computed
+
+JavaScript floats lose precision above 2⁵³ and produce surprises like `0.1 + 0.2 = 0.30000000000000004`. The package documents `string | number` input, but strings round-trip cleanly:
+
+```ts
+// Risky — arithmetic results may render unexpectedly:
+const total = subtotal + tax;
+new Tafgeet(total, 'EGP').parse();
+
+// Safe — string preserves your computed precision:
+new Tafgeet(total.toFixed(2), 'EGP').parse();
+```
+
+### Amounts must be ≥ 1
+
+`new Tafgeet('0', 'EGP')` and `new Tafgeet('0.50', 'EGP')` both throw `AmountOutOfRangeError`. The Arabic dictionary has no word for zero and the column logic assumes at least one integer digit. If you compute an amount that might round below 1:
+
+```ts
+const a = Math.max(1, Math.ceil(amount));
+new Tafgeet(a.toString(), 'EGP').parse();
+```
+
+### Very large or very small numbers must be strings
+
+Numbers ≥ 10²¹ and < 10⁻⁶ stringify in scientific notation (`'1e+21'`), which the package rejects since v1.2.1 (it used to silently corrupt them). Pass them as strings:
+
+```ts
+// Throws AmountOutOfRangeError:
+new Tafgeet(1e21, 'EGP');
+
+// Works:
+new Tafgeet('1000000000000000000000', 'EGP');
+```
+
+### No-currency mode is for integers only
+
+`new Tafgeet('1.50', '')` throws since v1.2.1 (silently dropped the cents pre-1.2.1). Either pass an integer or specify a currency:
+
+```ts
+new Tafgeet('150', '').parse();          // ok — pure integer
+new Tafgeet('1.50', 'EGP').parse();     // ok — with currency
+new Tafgeet('1.50', '');                 // throws — ambiguous
+new Tafgeet('1.0', '').parse();          // ok — all-zero fraction
+```
+
+### `read()` validates strictly
+
+`Tafgeet.prototype.read(d)` throws on anything outside `0..999` since v1.2.1 (used to silently return `''`). Always pass a finite integer in range.
+
+### Strict options validation
+
+Unknown option keys throw — including typos like `{ Rounding: 'round' }`. Stick to the documented `TafgeetOptions` shape; the v1.2.1 strict mode catches typos at runtime that TypeScript catches at compile time.
+
 ## Supported currencies
 
 | Code | Currency | Decimals |
@@ -248,21 +305,18 @@ Missing a currency? [Open an issue](https://github.com/omar-ehab/tafgeet-arabic/
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md). Highlights of **v1.2.0**:
+See [CHANGELOG.md](./CHANGELOG.md).
 
-- **Dual ESM + CJS build** with proper `exports` map and `sideEffects: false`
-- **`CurrencyCode` union type** + **`SUPPORTED_CURRENCIES`** runtime array
-- **Arabic-Indic digits & thousands separators** accepted (`'١٬٥٠٠٫٢٥'`, `'1,500.25'`, `'1_500'`, …)
-- **Custom error classes** with discriminated `code` fields (still `instanceof TypeError` etc.)
-- **`rounding` option** — `'truncate'` *(default, preserves v1.1 behavior)*, `'round'`, `'floor'`, `'ceil'`, `'bankers'`
-- **262 snapshot tests** locking in every existing output against future regression
+**v1.2.1** (latest patch) — eight correctness and hardening fixes found across two audit passes. Most notably: `'1.5' EGP` now correctly renders 50 piasters (not 5); `Number.MAX_VALUE` and other exponential-notation numbers now throw instead of silently corrupting; rounding can now carry from `0.999` up to `1`; strict options validation catches typos. See the v1.2.1 entry in the CHANGELOG for the full list. No new APIs.
 
-Earlier: **v1.1.0** — 3.5–4.7× faster, 52% smaller install, fixes for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7) / [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8) / fraction-plural, KWD added, input validation.
+**v1.2.0** — dual ESM/CJS build, `CurrencyCode` union type, Arabic-Indic & thousands-separator input, typed error classes, `rounding` option, 262 snapshot tests.
+
+**v1.1.0** — 3.5–4.7× faster, 52% smaller install, fixes for issues [#7](https://github.com/omar-ehab/tafgeet-arabic/issues/7) / [#8](https://github.com/omar-ehab/tafgeet-arabic/issues/8) / fraction-plural, KWD added, input validation.
 
 ## Roadmap
 
-- **v1.3:** currency registry (`registerCurrency`), `precision` option, more currencies (BHD, OMR, JOD, IQD, LBP, MAD, DZD, …)
-- **v1.4:** grammar options (`feminine`, `accusative`, `style: 'simple' | 'formal' | 'banking'`) — pending native-speaker review of the dictionaries
+- **v1.3:** 14 more currencies (10 Arab-region + 4 international: BHD, OMR, JOD, IQD, LYD, LBP, MAD, DZD, SYP, YER, EUR, GBP, CHF, CAD)
+- **v1.4:** native-speaker grammar review of the Arabic dictionaries; grammar options (`feminine`, `accusative`); style modes — all pending native review
 - Optional: functional API `tafgeet(amount, currency?)` alongside the class
 
 ## Contributing
@@ -273,7 +327,7 @@ PRs and issues welcome. To set up locally:
 git clone https://github.com/omar-ehab/tafgeet-arabic
 cd tafgeet-arabic
 npm install
-npm test               # 465 tests (107 unit + 262 snapshot + 96 feature)
+npm test               # 555 tests (107 unit + 262 snapshot + 186 feature/regression)
 npm run lint           # ESLint
 npm run test:js-compat # CJS + ESM smoke tests against built dist/
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tafgeet-arabic",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Converts currency digits into written Arabic words",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Patch release shipping 8 bug fixes found across two audit passes. **No new APIs, no new options, no breaking changes** for any input that was previously correctly handled.

## What this PR contains

- `package.json` + `package-lock.json` bumped 1.2.0 → 1.2.1
- `CHANGELOG.md` — full v1.2.1 entry covering all 8 fixes (Keep a Changelog format)
- `README.md` — new **"Common pitfalls"** section + Changelog/Roadmap blocks updated + test count bumped to 555

## All 8 fixes shipped in v1.2.1 (recap)

| # | Bug | Impact |
|---|---|---|
| 1+2 | Short fractions not padded to currency precision (`'1.5' EGP` → 5 piasters) | **Correctness** — fixed real interpretation bug |
| 3 | Rounding couldn't carry from `<1` up to `1` | **Correctness** |
| 4 (A) | **CRITICAL:** number inputs in scientific notation silently corrupted | **Critical correctness** — `Number.MAX_VALUE` rendered as 1.79 EGP |
| 5 (a–d) | Options validation silent failures (4 sub-bugs) | **API hygiene** |
| 6 | Currency whitespace not trimmed | **DX** |
| 7 | No-currency mode silently dropped fractional input | **Data integrity** |
| 8 (B) | `read()` silently returned `''` for invalid input | **API hygiene** |
| 9 (C+D) | `parse()` didn't re-validate state after mutation | **Defense in depth** |

## Verified

- ✅ 555 passing tests (was 465 at v1.2.0; **+90 regression tests** across the 8 fixes)
- ✅ `npm run lint` — clean
- ✅ `npm run format:check` — clean
- ✅ `npm run typecheck` — clean
- ✅ CJS + ESM smoke tests both pass
- ✅ `npm audit` — **0 vulnerabilities**
- ✅ `npm pack --dry-run` — 18.3 kB tarball, 72.6 kB unpacked (+1.2 kB vs v1.2.0 for new validation paths)
- ✅ Every README code example executed against built `dist/` and verified byte-identical

## Package size note

The +1.2 kB comes from:
- New validation paths (~0.5 kB across `validateOptions`, scientific-notation check, `read()` validation, `parse()` state checks)
- Richer JSDoc on the public API (~0.7 kB across `.d.ts` files)

Net: small price for two-audit-pass bug coverage.