### PR TITLE
chore: release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ try {
   new Tafgeet(1, 'XYZ');
 } catch (err) {
   // err instanceof Error
-  // err.message === 'Tafgeet: unknown currency "XYZ". Supported: SDG, SAR, QAR, AED, EGP, KWD, USD, AUD, TND, TRY'
+  // err.message === 'Tafgeet: unknown currency "XYZ". Supported: SDG, SAR, QAR, AED, EGP, KWD, USD, AUD, TND, TRY, BHD, OMR, JOD, IQD, LYD, LBP, MAD, DZD, SYP, YER, EUR, GBP, CHF, CAD'
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tafgeet-arabic",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Converts currency digits into written Arabic words",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
Release v1.3.0 — 14 new currencies (10 Arab-region + 4 international), total 10 → 24.

- Version bump 1.2.1 → 1.3.0, lockfile synced (0 vulnerabilities)
- Fixed stale unknown-currency error example in README (now lists all 24 codes)
- Every documented README example verified against built dist/

## Backward compatibility
Zero breaking changes. 885 tests pass; the 262 original snapshot rows are unchanged.

## Pipeline
lint / format:check / typecheck / build / test / test:js-compat — all green.