### PR TITLE
chore: release 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tafgeet-arabic",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tafgeet-arabic",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Converts currency digits into written Arabic words",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Release **v1.4.0** — the native-speaker Arabic-grammar pass (gender agreement, classical 1/2 forms, governing-number noun selection, spelling fixes), landed in #35.

- Version bump `1.3.0 → 1.4.0` + `package-lock.json` synced (0 vulnerabilities)
- `CHANGELOG.md` `## [1.4.0]` entry and the README "Arabic grammar" section already merged in #35
- Zero breaking changes — public API and the `Currency` type are unchanged; grammar fields live on an internal `CurrencyEntry`

## Test plan

- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` — clean
- [x] `npm test` — 1064 passing
- [x] `npm run test:js-compat` — CJS + ESM smoke tests pass against built `dist/`
- [x] Every documented README example verified against the built output
